### PR TITLE
Retrieve the appropriate operation type with operation definition

### DIFF
--- a/tartiflette/parser/cffi/__init__.py
+++ b/tartiflette/parser/cffi/__init__.py
@@ -442,12 +442,25 @@ class _VisitorElementFragmentDefinition(_VisitorElement):
         return None
 
 
+class _VisitorElementOperationDefinition(_VisitorElement):
+    def __init__(self, lib, ffi, internal_element):
+        super().__init__(lib, ffi, "OperationDefinition", internal_element)
+
+    def get_operation(self):
+        return self._from_char_to_string(
+            self._lib.GraphQLAstOperationDefinition_get_operation(
+                self._internal_element
+            )
+        ).capitalize()
+
+
 _LIBGRAPHQL_TYPE_TO_CLASS = {
     "IntValue": _VisitorElementIntValue,
     "StringValue": _VisitorElementStringValue,
     "FloatValue": _VisitorElementFloatValue,
     "BooleanValue": _VisitorElementBooleanValue,
     "FragmentDefinition": _VisitorElementFragmentDefinition,
+    "OperationDefinition": _VisitorElementOperationDefinition,
 }
 
 

--- a/tartiflette/schema/schema.py
+++ b/tartiflette/schema/schema.py
@@ -22,6 +22,10 @@ from tartiflette.types.scalar import GraphQLScalarType
 from tartiflette.types.type import GraphQLType
 from tartiflette.types.union import GraphQLUnionType
 
+_DEFAULT_QUERY_TYPE = "Query"
+_DEFAULT_MUTATION_TYPE = "Mutation"
+_DEFAULT_SUBSCRIPTION_TYPE = "Subscription"
+
 
 class GraphQLSchema:
     """
@@ -36,9 +40,9 @@ class GraphQLSchema:
             self.description = """A GraphQL Schema contains the complete definition of the GraphQL structure: types, entrypoints (query, mutation, subscription)."""
 
         # Schema entry points
-        self._query_type: Optional[str] = "Query"
-        self._mutation_type: Optional[str] = "Mutation"
-        self._subscription_type: Optional[str] = "Subscription"
+        self._query_type: Optional[str] = _DEFAULT_QUERY_TYPE
+        self._mutation_type: Optional[str] = _DEFAULT_MUTATION_TYPE
+        self._subscription_type: Optional[str] = _DEFAULT_SUBSCRIPTION_TYPE
         # Types, definitions and implementations
         self._gql_types: Dict[str, GraphQLType] = {}
         # Directives
@@ -104,6 +108,15 @@ class GraphQLSchema:
     @subscription_type.setter
     def subscription_type(self, value: str) -> None:
         self._subscription_type = value
+
+    def get_operation_type(self, operation_name):
+        if operation_name == _DEFAULT_QUERY_TYPE:
+            return self.query_type
+        if operation_name == _DEFAULT_MUTATION_TYPE:
+            return self.mutation_type
+        if operation_name == _DEFAULT_SUBSCRIPTION_TYPE:
+            return self.subscription_type
+        return None
 
     #  Introspection Attribute
     @property

--- a/tests/functional/test_mutations.py
+++ b/tests/functional/test_mutations.py
@@ -1,0 +1,105 @@
+from collections import namedtuple
+
+import pytest
+
+from tartiflette import Resolver
+from tartiflette.engine import Engine
+
+
+@pytest.mark.asyncio
+async def test_full_mutation_execute():
+    schema_sdl = """
+    enum Status {
+        SUCCESS
+    }
+
+    schema {
+        query: CustomRootQuery
+        mutation: CustomRootMutation
+    }
+
+    type CustomRootQuery {
+        books: [Book]
+    }
+
+    type Book {
+        title: String
+        price: Float
+    }
+
+    type CustomRootMutation {
+        addBook(input: AddBookInput!): AddBookPayload
+    }
+
+    input AddBookInput {
+        clientMutationId: String
+        title: String!
+        price: Float!
+    }
+
+    type AddBookPayload {
+        status: Status
+        clientMutationId: String
+        book: Book
+    }
+    """
+
+    Book = namedtuple("Book", ("title", "price"))
+
+    data_store = [
+        Book(title="The Jungle Book", price=14.99),
+    ]
+
+    @Resolver("CustomRootMutation.addBook")
+    async def add_book_resolver(_, args, *__):
+        added_book = Book(
+            title=args["input"]["title"],
+            price=args["input"]["price"],
+        )
+        data_store.append(added_book)
+        return {
+            "clientMutationId": args["input"].get("clientMutationId"),
+            "status": "SUCCESS",
+            "book": added_book,
+        }
+
+    assert len(data_store) == 1
+
+    ttftt = Engine(schema_sdl)
+
+    result = await  ttftt.execute(
+        """
+        mutation AddBook($input: AddBookInput!) {
+          addBook(input: $input) {
+            status
+            clientMutationId
+            book {
+                title
+                price
+            }
+          }
+        }
+        """,
+        variables={
+            "input": {
+                "clientMutationId": 1,
+                "title": "My Book",
+                "price": 9.99,
+            }
+        }
+    )
+
+    assert len(data_store) == 2
+
+    assert {
+        "data": {
+            "addBook": {
+                "clientMutationId": "1",
+                "status": "SUCCESS",
+                "book": {
+                    "title": "My Book",
+                    "price": 9.99,
+                },
+            },
+        },
+    } == result


### PR DESCRIPTION
The goal of this PR is to deduct the actual operation type for each root node and fix mutations resolve.

Before, if the GraphQL type of the parent node wasn't deductible, we would fallback to the `Query` type. However, this makes impossible to resolve mutations and other operation types. From now, the operation type is deduced using the OperationDefinition.