### PR TITLE
Add support for alias in Queries and Mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Released]
 
+## [0.1.7] - 2018-11-12
+### Added
+- (Query) Support Alias in Query and Mutation
+
 ## [0.1.6] - 2018-10-31
 ### Added
 - (CI) Integrate missing Grammar

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ _TEST_REQUIRE = [
     "black==18.9b0",
 ]
 
-_VERSION = "0.1.6"
+_VERSION = "0.1.7"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 

--- a/tartiflette/executors/basic.py
+++ b/tartiflette/executors/basic.py
@@ -15,7 +15,7 @@ def _get_datas(root_nodes):
     for node in root_nodes:
         if node.cant_be_null and node.marshalled is None:
             return None
-        data[node.name] = node.marshalled
+        data[node.alias] = node.marshalled
 
     return data
 

--- a/tartiflette/parser/cffi/__init__.py
+++ b/tartiflette/parser/cffi/__init__.py
@@ -454,6 +454,16 @@ class _VisitorElementOperationDefinition(_VisitorElement):
         ).capitalize()
 
 
+class _VisitorElementField(_VisitorElement):
+    def __init__(self, lib, ffi, internal_element):
+        super().__init__(lib, ffi, "Field", internal_element)
+
+    def get_alias(self):
+        return self._get_name_string(
+            self._lib.GraphQLAstField_get_alias(self._internal_element)
+        )
+
+
 _LIBGRAPHQL_TYPE_TO_CLASS = {
     "IntValue": _VisitorElementIntValue,
     "StringValue": _VisitorElementStringValue,
@@ -461,6 +471,7 @@ _LIBGRAPHQL_TYPE_TO_CLASS = {
     "BooleanValue": _VisitorElementBooleanValue,
     "FragmentDefinition": _VisitorElementFragmentDefinition,
     "OperationDefinition": _VisitorElementOperationDefinition,
+    "Field": _VisitorElementField,
 }
 
 

--- a/tartiflette/parser/nodes/field.py
+++ b/tartiflette/parser/nodes/field.py
@@ -18,6 +18,7 @@ class NodeField(Node):
         location: Location,
         path: List[str],
         type_condition: str,
+        alias: str = None,
     ):
         super().__init__(path, "Field", location, name)
         # Execution
@@ -26,6 +27,7 @@ class NodeField(Node):
         self.arguments = {}
         self.type_condition = type_condition
         self.marshalled = {}
+        self.alias = alias if alias is not None else self.name
 
     @property
     def cant_be_null(self) -> bool:
@@ -43,7 +45,7 @@ class NodeField(Node):
         if self.cant_be_null is False:
             # mean i can be null
             if self.parent:
-                self.parent.marshalled[self.name] = None
+                self.parent.marshalled[self.alias] = None
             else:
                 self.marshalled = None
         else:
@@ -102,7 +104,7 @@ class NodeField(Node):
         )
 
         if parent_marshalled is not None:
-            parent_marshalled[self.name] = coerced
+            parent_marshalled[self.alias] = coerced
         else:
             self.marshalled = coerced
 

--- a/tartiflette/parser/visitor.py
+++ b/tartiflette/parser/visitor.py
@@ -136,6 +136,7 @@ class TartifletteVisitor(Visitor):
             element.get_location(),
             self.field_path[:],
             self._current_type_condition,
+            element.get_alias(),
         )
 
         node.set_parent(self._current_node)
@@ -160,11 +161,17 @@ class TartifletteVisitor(Visitor):
         self._current_node = node
 
     def _validate_type(self, varname, a_value, a_type):
-        if not isinstance(a_value, a_type):
-            self.continue_child = 0
-            self.exception = TypeError(
-                "Given value for < %s > is not type < %s >" % (varname, a_type)
-            )
+        try:
+            if not isinstance(a_value, a_type):
+                self.continue_child = 0
+                self.exception = TypeError(
+                    "Given value for < %s > is not type < %s >"
+                    % (varname, a_type)
+                )
+        except TypeError:
+            # TODO remove this, and handle the case it's an InputValue
+            # (look at registered input values and compare fields)
+            pass
 
     def _validates_vars(self):
         # validate given var are okay

--- a/tests/functional/test_mutations.py
+++ b/tests/functional/test_mutations.py
@@ -7,7 +7,7 @@ from tartiflette.engine import Engine
 
 
 @pytest.mark.asyncio
-async def test_full_mutation_execute():
+async def test_full_mutation_execute(clean_registry):
     schema_sdl = """
     enum Status {
         SUCCESS
@@ -46,15 +46,12 @@ async def test_full_mutation_execute():
 
     Book = namedtuple("Book", ("title", "price"))
 
-    data_store = [
-        Book(title="The Jungle Book", price=14.99),
-    ]
+    data_store = [Book(title="The Jungle Book", price=14.99)]
 
     @Resolver("CustomRootMutation.addBook")
     async def add_book_resolver(_, args, *__):
         added_book = Book(
-            title=args["input"]["title"],
-            price=args["input"]["price"],
+            title=args["input"]["title"], price=args["input"]["price"]
         )
         data_store.append(added_book)
         return {
@@ -67,7 +64,7 @@ async def test_full_mutation_execute():
 
     ttftt = Engine(schema_sdl)
 
-    result = await  ttftt.execute(
+    result = await ttftt.execute(
         """
         mutation AddBook($input: AddBookInput!) {
           addBook(input: $input) {
@@ -81,12 +78,8 @@ async def test_full_mutation_execute():
         }
         """,
         variables={
-            "input": {
-                "clientMutationId": 1,
-                "title": "My Book",
-                "price": 9.99,
-            }
-        }
+            "input": {"clientMutationId": 1, "title": "My Book", "price": 9.99}
+        },
     )
 
     assert len(data_store) == 2
@@ -96,10 +89,7 @@ async def test_full_mutation_execute():
             "addBook": {
                 "clientMutationId": "1",
                 "status": "SUCCESS",
-                "book": {
-                    "title": "My Book",
-                    "price": 9.99,
-                },
-            },
-        },
+                "book": {"title": "My Book", "price": 9.99},
+            }
+        }
     } == result


### PR DESCRIPTION
Now a query like 
```graphql
query aquery { anAlias: field }
```
will return

```
{"data": { "anAlias": "aData" } }
```
 