### PR TITLE
Some fixes & improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Adds manually path & locations attributes to the `UnknownSchemaFieldResolver` raised exception.
+
+### Fixed
+
+- Parse raw GraphQL query in order to have the correct locations on raised errors.
+- Avoid `TypeError` by re-raising `UnknownSchemaFieldResolver` or casting `_inline_fragment_type` to string.
+
 ## [Release]
 
 ### [0.2.2] - 2019-01-04

--- a/tartiflette/parser/cffi/__init__.py
+++ b/tartiflette/parser/cffi/__init__.py
@@ -570,8 +570,7 @@ class LibGraphqlParser:
 
     def _parse(self, query):
         if isinstance(query, str):
-            # TODO don't replace here.
-            query = query.replace("\n", " ").encode("UTF-8")
+            query = query.encode("UTF-8")
 
         c_query = self._ffi.new("char[]", query)
         parsed_data = _ParsedData(

--- a/tartiflette/parser/visitor.py
+++ b/tartiflette/parser/visitor.py
@@ -129,8 +129,10 @@ class TartifletteVisitor(Visitor):
             )
         except UnknownSchemaFieldResolver as e:
             try:
+                if not self._inline_fragment_type:
+                    raise
                 field = self.schema.get_field_by_name(
-                    self._inline_fragment_type + "." + element.name
+                    str(self._inline_fragment_type) + "." + element.name
                 )
             except UnknownSchemaFieldResolver as e:
                 self.continue_child = 0

--- a/tartiflette/parser/visitor.py
+++ b/tartiflette/parser/visitor.py
@@ -136,6 +136,8 @@ class TartifletteVisitor(Visitor):
                 )
             except UnknownSchemaFieldResolver as e:
                 self.continue_child = 0
+                e.path = self.field_path[:]
+                e.locations = [element.get_location()]
                 self.exception = e
                 return
 

--- a/tests/functional/test_empty_value.py
+++ b/tests/functional/test_empty_value.py
@@ -21,7 +21,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": None},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `String!`",
                         "path": ["obj", "field"],
                     }
@@ -42,7 +42,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": {"field": None}},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `[String!]`",
                         "path": ["obj", "field"],
                     }
@@ -57,7 +57,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": None},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `[String]!`",
                         "path": ["obj", "field"],
                     }
@@ -72,7 +72,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": None},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `[String!]!`",
                         "path": ["obj", "field"],
                     }
@@ -87,7 +87,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": None},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `[String!]!`",
                         "path": ["obj", "field"],
                     }
@@ -135,7 +135,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": {"field": None}},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `[[String!]]`",
                         "path": ["obj", "field"],
                     }
@@ -150,7 +150,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": {"field": None}},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `[[String!]!]`",
                         "path": ["obj", "field"],
                     }
@@ -165,7 +165,7 @@ from tartiflette.engine import Engine
                 "data": {"obj": None},
                 "errors": [
                     {
-                        "locations": [{"column": 64, "line": 1}],
+                        "locations": [{"column": 13, "line": 4}],
                         "message": "Invalid value (value: None) for field `field` of type `[[String!]!]!`",
                         "path": ["obj", "field"],
                     }
@@ -256,7 +256,7 @@ async def test_tartiflette_execute_bubble_up_empty_value(clean_registry):
         "data": None,
         "errors": [
             {
-                "locations": [{"column": 104, "line": 1}],
+                "locations": [{"column": 21, "line": 5}],
                 "message": "Invalid value (value: None) for field `fieldAgain` of type `Int!`",
                 "path": ["obj", "field", "fieldAgain"],
             }

--- a/tests/functional/types/exceptions/test_tartiflette_errors.py
+++ b/tests/functional/types/exceptions/test_tartiflette_errors.py
@@ -52,7 +52,7 @@ async def test_tartiflette_execute_nested_error(clean_registry):
             {
                 "message": "Invalid value (value: None) for field `lastUpdate` of type `[Float!]`",
                 "path": ["test", "deep", "lastUpdate"],
-                "locations": [{"line": 1, "column": 68}],
+                "locations": [{"line": 5, "column": 17}],
             }
         ],
     } == result

--- a/tests/functional/types/test_enum.py
+++ b/tests/functional/types/test_enum.py
@@ -49,7 +49,7 @@ async def test_tartiflette_execute_enum_type_output(clean_registry):
                     {
                         "message": "Invalid value (value: None) for field `testField` of type `Test!`",
                         "path": ["testField"],
-                        "locations": [{"line": 1, "column": 26}],
+                        "locations": [{"line": 3, "column": 9}],
                     }
                 ],
             },
@@ -68,7 +68,7 @@ async def test_tartiflette_execute_enum_type_output(clean_registry):
                     {
                         "message": "Invalid value (value: 'UnknownValue') for field `testField` of type `[Test]`",
                         "path": ["testField"],
-                        "locations": [{"line": 1, "column": 26}],
+                        "locations": [{"line": 3, "column": 9}],
                     }
                 ],
             },

--- a/tests/functional/types/test_object.py
+++ b/tests/functional/types/test_object.py
@@ -56,7 +56,7 @@ async def test_tartiflette_execute_object_type_output(clean_registry):
                     {
                         "message": "Invalid value (value: None) for field `testField` of type `Test!`",
                         "path": ["testField"],
-                        "locations": [{"line": 1, "column": 26}],
+                        "locations": [{"line": 3, "column": 9}],
                     }
                 ],
             },

--- a/tests/functional/types/test_scalar.py
+++ b/tests/functional/types/test_scalar.py
@@ -47,7 +47,7 @@ async def test_tartiflette_execute_scalar_type_output(clean_registry):
                     {
                         "message": "Invalid value (value: None) for field `testField` of type `String!`",
                         "path": ["testField"],
-                        "locations": [{"line": 1, "column": 26}],
+                        "locations": [{"line": 3, "column": 9}],
                     }
                 ],
             },
@@ -134,7 +134,7 @@ async def test_tartiflette_execute_scalar_type_output(clean_registry):
                     {
                         "message": "Invalid value (value: None) for field `testField` of type `[DateTime!]`",
                         "path": ["testField"],
-                        "locations": [{"line": 1, "column": 26}],
+                        "locations": [{"line": 3, "column": 9}],
                     }
                 ],
             },


### PR DESCRIPTION
* b03b2877222d2afcf6b6894d4e62a3ba628faaa7 Removes replacement of breaking lines in order to parse the raw GraphQL query and have the correct locations on errors
* 1d61cfcd56167df3bde1440f0258cfa0b7ab6cd8 Re-raise `UnknownSchemaFieldResolver` if no `_inline_fragment_type` or cast it to a string if set to avoid any `TypeError` exception
* 5d98fd6658d257cc1da46f2d9aa1f09bf6986259 Adds manually `path` & `locations` attributes to the `Unknown SchemaFieldResolver` raised exception