### PR TITLE
Handle custom exception errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Allows to handle custom exeception errors.
+
+```python
+class BadRequestError(Exception):
+    def coerce_value(self, *_args, path=None, locations=None, **_kwargs):
+        return your_coerced_error
+
+
+@Resolver("Query.hello")
+async def resolver_hello(parent, args, ctx, info):
+    if args["name"] == "":
+        raise BadRequestError("`name` argument shouldn't by empty.")
+    return "hello " + args["name"]
+```
+
 - Adds manually path & locations attributes to the `UnknownSchemaFieldResolver` raised exception.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ async def resolver_hello(parent, args, ctx, info):
 ```
 - Enable you to override the `default_error_coercer` at Engine initialization time:
 ```python
-async def my_error_coercer(exception) -> dict:
+def my_error_coercer(exception) -> dict:
     do_ing_some_thin_gs = 42
     return a_value
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Allows to handle custom exeception errors.
-
-- Coerce exception raised during query parsing instead of throwing them.
-
+- Allows to handle custom exception errors.
+- Coerce exception raised during query parsing instead of throwing them:
 ```python
 class BadRequestError(Exception):
     def coerce_value(self, *_args, path=None, locations=None, **_kwargs):
@@ -25,13 +23,22 @@ async def resolver_hello(parent, args, ctx, info):
         raise BadRequestError("`name` argument shouldn't by empty.")
     return "hello " + args["name"]
 ```
+- Enable you to override the `default_error_resolver` at Engine initialization time:
+```python
+async def my_error_resolver(exception) -> dict:
+    do_ing_some_thin_gs = 42
+    return a_value
 
+e = Engine("my_sdl.sdl", error_resolver=my_error_resolver)
+```
 - Adds manually path & locations attributes to the `UnknownSchemaFieldResolver` raised exception.
+- Returns all encountered errors during query parsing instead of only the last one.
 
 ### Fixed
 
 - Parse raw GraphQL query in order to have the correct locations on raised errors.
 - Avoid `TypeError` by re-raising `UnknownSchemaFieldResolver` or casting `_inline_fragment_type` to string.
+- Raise `GraphQLError` instead of builtin exceptions.
 
 ## [Release]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Allows to handle custom exeception errors.
 
+- Coerce exception raised during query parsing instead of throwing them.
+
 ```python
 class BadRequestError(Exception):
     def coerce_value(self, *_args, path=None, locations=None, **_kwargs):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,13 @@ async def resolver_hello(parent, args, ctx, info):
         raise BadRequestError("`name` argument shouldn't by empty.")
     return "hello " + args["name"]
 ```
-- Enable you to override the `default_error_resolver` at Engine initialization time:
+- Enable you to override the `default_error_coercer` at Engine initialization time:
 ```python
-async def my_error_resolver(exception) -> dict:
+async def my_error_coercer(exception) -> dict:
     do_ing_some_thin_gs = 42
     return a_value
 
-e = Engine("my_sdl.sdl", error_resolver=my_error_resolver)
+e = Engine("my_sdl.sdl", error_coercer=my_error_coercer)
 ```
 - Adds manually path & locations attributes to the `UnknownSchemaFieldResolver` raised exception.
 - Returns all encountered errors during query parsing instead of only the last one.

--- a/tartiflette/engine.py
+++ b/tartiflette/engine.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from tartiflette.executors.basic import execute as basic_execute
 from tartiflette.parser import TartifletteRequestParser
-from tartiflette.resolver.factory import default_error_resolver
+from tartiflette.resolver.factory import default_error_coercer
 from tartiflette.schema.registry import SchemaRegistry
 from tartiflette.schema.bakery import SchemaBakery
 from tartiflette.types.exceptions.tartiflette import GraphQLError
@@ -13,12 +13,12 @@ class Engine:
         self,
         sdl,
         schema_name="default",
-        error_resolver=default_error_resolver,
+        error_coercer=default_error_coercer,
         custom_default_resolver=None,
         exclude_builtins_scalars=None,
     ):
         # TODO: Use the kwargs and add them to the schema
-        self._error_resolver = error_resolver
+        self._error_coercer = error_coercer
         # schema can be: file path, file list, folder path, schema object
         self._parser = TartifletteRequestParser()
         SchemaRegistry.register_sdl(schema_name, sdl, exclude_builtins_scalars)
@@ -54,11 +54,9 @@ class Engine:
         if errors:
             return {
                 "data": None,
-                "errors": [self._error_resolver(err) for err in errors],
+                "errors": [self._error_coercer(err) for err in errors],
             }
 
         return await basic_execute(
-            root_nodes,
-            request_ctx=context,
-            error_resolver=self._error_resolver,
+            root_nodes, request_ctx=context, error_coercer=self._error_coercer
         )

--- a/tartiflette/executors/basic.py
+++ b/tartiflette/executors/basic.py
@@ -20,13 +20,15 @@ def _get_datas(root_nodes):
     return data
 
 
-async def execute(root_nodes, request_ctx):
+async def execute(root_nodes, request_ctx, error_resolver):
     results = {"data": {}, "errors": []}
     exec_ctx = ExecutionContext()
 
     await _execute(root_nodes, exec_ctx, request_ctx)
 
-    results["errors"] += [err.coerce_value() for err in exec_ctx.errors if err]
+    results["errors"] += [
+        error_resolver(err) for err in exec_ctx.errors if err
+    ]
     results["data"] = _get_datas(root_nodes)
 
     if not results["errors"]:

--- a/tartiflette/executors/basic.py
+++ b/tartiflette/executors/basic.py
@@ -20,15 +20,13 @@ def _get_datas(root_nodes):
     return data
 
 
-async def execute(root_nodes, request_ctx, error_resolver):
+async def execute(root_nodes, request_ctx, error_coercer):
     results = {"data": {}, "errors": []}
     exec_ctx = ExecutionContext()
 
     await _execute(root_nodes, exec_ctx, request_ctx)
 
-    results["errors"] += [
-        error_resolver(err) for err in exec_ctx.errors if err
-    ]
+    results["errors"] += [error_coercer(err) for err in exec_ctx.errors if err]
     results["data"] = _get_datas(root_nodes)
 
     if not results["errors"]:

--- a/tartiflette/parser/cffi/__init__.py
+++ b/tartiflette/parser/cffi/__init__.py
@@ -2,6 +2,7 @@ import os
 from functools import partial
 
 from cffi import FFI
+from tartiflette.types.exceptions.tartiflette import GraphQLError
 
 from tartiflette.types.location import Location
 
@@ -580,7 +581,7 @@ class LibGraphqlParser:
 
         if self._errors[0] != self._ffi.NULL:
             # TODO specialize Exception here
-            e = Exception(
+            e = GraphQLError(
                 self._ffi.string(self._errors[0]).decode("UTF-8", "replace")
             )
             self._lib.graphql_error_free(self._errors[0])

--- a/tartiflette/parser/parser.py
+++ b/tartiflette/parser/parser.py
@@ -15,6 +15,6 @@ class TartifletteRequestParser(LibGraphqlParser):
 
         visitor = TartifletteVisitor(schema, variables)
         self.parse_and_visit(query, visitor)
-        if visitor.exception:
-            raise visitor.exception  # pylint: disable=raising-bad-type
-        return visitor.root_nodes
+        if visitor.exceptions:
+            return None, visitor.exceptions  # pylint: disable=raising-bad-type
+        return visitor.root_nodes, None

--- a/tartiflette/parser/visitor.py
+++ b/tartiflette/parser/visitor.py
@@ -11,6 +11,7 @@ from tartiflette.types.exceptions.tartiflette import (
     TartifletteException,
     UnknownSchemaFieldResolver,
     UnknownVariableException,
+    GraphQLError,
 )
 from tartiflette.types.helpers import reduce_type
 
@@ -177,7 +178,7 @@ class TartifletteVisitor(Visitor):
             if not isinstance(a_value, a_type):
                 self.continue_child = 0
                 self.exceptions.append(
-                    TypeError(
+                    GraphQLError(
                         "Given value for < %s > is not type < %s >"
                         % (varname, a_type)
                     )
@@ -207,7 +208,7 @@ class TartifletteVisitor(Visitor):
             if not isinstance(a_value, list):
                 self.continue_child = 0
                 self.exceptions.append(
-                    TypeError("Expecting List for < %s > values" % name)
+                    GraphQLError("Expecting List for < %s > values" % name)
                 )
                 return None
 

--- a/tartiflette/parser/visitor.py
+++ b/tartiflette/parser/visitor.py
@@ -1,5 +1,5 @@
 from functools import lru_cache, partial
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from tartiflette.parser.cffi import (
     Visitor,
@@ -78,7 +78,7 @@ class TartifletteVisitor(Visitor):
         self._current_fragment_definition = None
         self._fragments = {}
         self.schema: GraphQLSchema = schema
-        self.exception: Exception = None
+        self.exceptions: List[Exception] = []
         self._inline_fragment_type = None
 
     def _on_argument_in(self, element: _VisitorElement):
@@ -108,7 +108,7 @@ class TartifletteVisitor(Visitor):
             )
         except KeyError:
             self.continue_child = 0
-            self.exception = UnknownVariableException(var_name)
+            self.exceptions.append(UnknownVariableException(var_name))
 
     def _on_field_in(self, element: _VisitorElement):
         self.field_path.append(element.name)
@@ -138,7 +138,7 @@ class TartifletteVisitor(Visitor):
                 self.continue_child = 0
                 e.path = self.field_path[:]
                 e.locations = [element.get_location()]
-                self.exception = e
+                self.exceptions.append(e)
                 return
 
         node = NodeField(
@@ -176,9 +176,11 @@ class TartifletteVisitor(Visitor):
         try:
             if not isinstance(a_value, a_type):
                 self.continue_child = 0
-                self.exception = TypeError(
-                    "Given value for < %s > is not type < %s >"
-                    % (varname, a_type)
+                self.exceptions.append(
+                    TypeError(
+                        "Given value for < %s > is not type < %s >"
+                        % (varname, a_type)
+                    )
                 )
         except TypeError:
             # TODO remove this, and handle the case it's an InputValue
@@ -192,7 +194,7 @@ class TartifletteVisitor(Visitor):
             dfv = self._current_node.default_value
             if not dfv and not self._current_node.is_nullable:
                 self.continue_child = 0
-                self.exception = UnknownVariableException(name)
+                self.exceptions.append(UnknownVariableException(name))
                 return None
 
             self._vars[name] = dfv
@@ -204,8 +206,8 @@ class TartifletteVisitor(Visitor):
         if self._current_node.is_list:
             if not isinstance(a_value, list):
                 self.continue_child = 0
-                self.exception = TypeError(
-                    "Expecting List for < %s > values" % name
+                self.exceptions.append(
+                    TypeError("Expecting List for < %s > values" % name)
                 )
                 return None
 
@@ -239,8 +241,10 @@ class TartifletteVisitor(Visitor):
     def _on_fragment_definition_in(self, element: _VisitorElement):
         if element.name in self._fragments:
             self.continue_child = 0
-            self.exception = TartifletteException(
-                "Fragment < %s > already defined" % element.name
+            self.exceptions.append(
+                TartifletteException(
+                    "Fragment < %s > already defined" % element.name
+                )
             )
             return
 

--- a/tartiflette/resolver/factory.py
+++ b/tartiflette/resolver/factory.py
@@ -255,7 +255,7 @@ async def default_resolver(
     return None
 
 
-def default_error_resolver(exception: Exception) -> dict:
+def default_error_coercer(exception: Exception) -> dict:
     return exception.coerce_value()
 
 

--- a/tartiflette/resolver/factory.py
+++ b/tartiflette/resolver/factory.py
@@ -255,6 +255,10 @@ async def default_resolver(
     return None
 
 
+def default_error_resolver(exception: Exception) -> dict:
+    return exception.coerce_value()
+
+
 class ResolverExecutorFactory:
     @staticmethod
     def get_resolver_executor(func, field):

--- a/tartiflette/types/exceptions/tartiflette.py
+++ b/tartiflette/types/exceptions/tartiflette.py
@@ -24,11 +24,17 @@ class GraphQLError(Exception):
         self.path = path if path else None
         self.locations = locations if locations else []
 
-    def coerce_value(self, *_args, **_kwargs):
-        locations = []
+    def coerce_value(
+        self,
+        *_args,
+        path: Optional[List[Any]] = None,
+        locations: Optional[List[Location]] = None,
+        **_kwargs,
+    ):
+        computed_locations = []
         try:
-            for loc in self.locations:
-                locations.append(loc.collect_value())
+            for location in locations or self.locations:
+                computed_locations.append(location.collect_value())
         except AttributeError:
             pass
         except TypeError:
@@ -37,8 +43,8 @@ class GraphQLError(Exception):
             "message": self.user_message
             if self.user_message
             else self.message,
-            "path": self.path,
-            "locations": locations,
+            "path": path or self.path,
+            "locations": computed_locations,
         }
 
 

--- a/tests/functional/regressions/test_issue21.py
+++ b/tests/functional/regressions/test_issue21.py
@@ -110,7 +110,16 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                 a(xid: $xid)
             }
             """,
-            UnknownVariableException,
+            {
+                "data": None,
+                "errors": [
+                    {
+                        "message": "< xid > is not known",
+                        "locations": [],
+                        "path": None,
+                    },
+                ],
+            },
             {},
         ),
         (
@@ -119,7 +128,16 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                 a(xid: $xid)
             }
             """,
-            TypeError,
+            {
+                "data": None,
+                "errors": [
+                    {
+                        "message": "Server encountered an error.",
+                        "locations": [],
+                        "path": None,
+                    },
+                ],
+            },
             {"xid": "RE"},
         ),
         (
@@ -128,7 +146,16 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                 a(xid: $xid)
             }
             """,
-            TypeError,
+            {
+                "data": None,
+                "errors": [
+                    {
+                        "message": "Server encountered an error.",
+                        "locations": [],
+                        "path": None,
+                    },
+                ],
+            },
             {"xid": "RE"},
         ),
         (
@@ -137,7 +164,16 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                 a(xid: $xid)
             }
             """,
-            TypeError,
+            {
+                "data": None,
+                "errors": [
+                    {
+                        "message": "Server encountered an error.",
+                        "locations": [],
+                        "path": None,
+                    },
+                ],
+            },
             {"xid": ["RE"]},
         ),
     ],
@@ -166,5 +202,4 @@ async def test_issue21_exceptquery(query, expected, varis, clean_registry):
     """
     )
 
-    with pytest.raises(expected):
-        await ttftt.execute(query, context={}, variables=varis)
+    assert await ttftt.execute(query, context={}, variables=varis) == expected

--- a/tests/functional/regressions/test_issue21.py
+++ b/tests/functional/regressions/test_issue21.py
@@ -118,6 +118,11 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                         "locations": [],
                         "path": None,
                     },
+                    {
+                        "message": "< xid > is not known",
+                        "locations": [],
+                        "path": None,
+                    },
                 ],
             },
             {},

--- a/tests/functional/regressions/test_issue21.py
+++ b/tests/functional/regressions/test_issue21.py
@@ -137,7 +137,7 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                 "data": None,
                 "errors": [
                     {
-                        "message": "Server encountered an error.",
+                        "message": "Given value for < xid > is not type < <class 'int'> >",
                         "locations": [],
                         "path": None,
                     },
@@ -155,7 +155,7 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                 "data": None,
                 "errors": [
                     {
-                        "message": "Server encountered an error.",
+                        "message": "Expecting List for < xid > values",
                         "locations": [],
                         "path": None,
                     },
@@ -173,7 +173,7 @@ from tartiflette.types.exceptions.tartiflette import UnknownVariableException
                 "data": None,
                 "errors": [
                     {
-                        "message": "Server encountered an error.",
+                        "message": "Given value for < xid > is not type < <class 'int'> >",
                         "locations": [],
                         "path": None,
                     },

--- a/tests/unit/executor/test_basic.py
+++ b/tests/unit/executor/test_basic.py
@@ -1,6 +1,6 @@
 import pytest
 import inspect
-from tartiflette.resolver.factory import default_error_resolver
+from tartiflette.resolver.factory import default_error_coercer
 from tartiflette.types.exceptions.tartiflette import GraphQLError
 from unittest.mock import Mock
 
@@ -87,7 +87,7 @@ async def test_executor_basic_execute(errors, expected, monkeypatch):
 
     from tartiflette.executors.basic import execute
 
-    a = await execute([], request_ctx={}, error_resolver=default_error_resolver)
+    a = await execute([], request_ctx={}, error_coercer=default_error_coercer)
 
     assert a == expected
 
@@ -101,15 +101,15 @@ async def test_executor_basic_execute_custom_resolver(monkeypatch):
     async def my_execute(_, exec_ctx, __):
         exec_ctx.add_error(GraphQLError("My error"))
 
-    def custom_error_resolver(exception):
-        return {"message": "Error from custom_error_resolver"}
+    def custom_error_coercer(exception):
+        return {"message": "Error from custom_error_coercer"}
 
     monkeypatch.setattr(basic, "_execute", my_execute)
 
     from tartiflette.executors.basic import execute
 
-    a = await execute([], request_ctx={}, error_resolver=custom_error_resolver)
+    a = await execute([], request_ctx={}, error_coercer=custom_error_coercer)
 
-    assert a == {"data": {}, "errors": [{"message": "Error from custom_error_resolver"}]}
+    assert a == {"data": {}, "errors": [{"message": "Error from custom_error_coercer"}]}
 
     monkeypatch.undo()

--- a/tests/unit/parser/test_parser.py
+++ b/tests/unit/parser/test_parser.py
@@ -25,7 +25,7 @@ def test_tartiflette_request_parser(clean_registry, monkeypatch):
 
     trp = TartifletteRequestParser()
 
-    assert trp.parse_and_tartify(None, "query aq { __schema }") == []
+    assert trp.parse_and_tartify(None, "query aq { __schema }") == ([], None)
 
     monkeypatch.undo()
 
@@ -42,7 +42,6 @@ def test_tartiflette_request_parser_vistor_except(clean_registry, monkeypatch):
 
     trp = TartifletteRequestParser()
 
-    with pytest.raises(Exception):
-        trp.parse_and_tartify(None, "query aq { __schema }")
+    assert trp.parse_and_tartify(None, "query aq { __schema }") == ([], None)
 
     monkeypatch.undo()

--- a/tests/unit/parser/test_visitor.py
+++ b/tests/unit/parser/test_visitor.py
@@ -1,4 +1,5 @@
 import pytest
+from tartiflette.types.exceptions.tartiflette import GraphQLError
 from unittest.mock import Mock
 
 
@@ -279,7 +280,7 @@ def test_parser_visitor__validate_type(a_visitor, an_element):
 
     a_visitor._validate_type("ntm", "a", int)
     assert a_visitor.exceptions is not None
-    assert isinstance(a_visitor.exceptions[0], TypeError)
+    assert isinstance(a_visitor.exceptions[0], GraphQLError)
     assert a_visitor.continue_child == 0
 
 
@@ -344,7 +345,7 @@ def test_parser_visitor__validate_vars_existing_okay_var_is_list_nok(
 
     assert a_visitor.continue_child == 0
     assert a_visitor.exceptions is not None
-    assert isinstance(a_visitor.exceptions[0], TypeError)
+    assert isinstance(a_visitor.exceptions[0], GraphQLError)
 
 
 def test_parser_visitor__validate_vars_existing_okay_var_has_a_dfv(

--- a/tests/unit/parser/test_visitor.py
+++ b/tests/unit/parser/test_visitor.py
@@ -97,15 +97,11 @@ def test_parser_visitor__on_variable_in_no_var_name_ukn_var(
     a_visitor._on_variable_in(an_element)
 
     assert a_visitor.continue_child == 0
-    assert a_visitor.exception is not None
-    assert isinstance(a_visitor.exception, UnknownVariableException)
+    assert a_visitor.exceptions is not None
+    assert isinstance(a_visitor.exceptions[0], UnknownVariableException)
 
 
 def test_parser_visitor__on_variable_in_no_var_name(a_visitor, an_element):
-    from tartiflette.types.exceptions.tartiflette import (
-        UnknownVariableException,
-    )
-
     del a_visitor._current_node.var_name
 
     a_visitor._current_node.arguments = {}
@@ -251,7 +247,7 @@ def test_parser_visitor__on_field_unknow_schema_field(a_visitor, an_element):
     ]
     assert a_visitor._current_node not in a_visitor.root_nodes
     assert a_visitor.continue_child == 0
-    assert a_visitor.exception == an_exception
+    assert a_visitor.exceptions[0] == an_exception
 
 
 def test_parser_visitor__on_field_out(a_visitor, an_element):
@@ -278,12 +274,12 @@ def test_parser_visitor__on_variable_definition_in(a_visitor, an_element):
 def test_parser_visitor__validate_type(a_visitor, an_element):
     a_visitor._validate_type("ninja", "a", str)
 
-    assert a_visitor.exception is None
+    assert a_visitor.exceptions == []
     assert a_visitor.continue_child == 1
 
     a_visitor._validate_type("ntm", "a", int)
-    assert a_visitor.exception is not None
-    assert isinstance(a_visitor.exception, TypeError)
+    assert a_visitor.exceptions is not None
+    assert isinstance(a_visitor.exceptions[0], TypeError)
     assert a_visitor.continue_child == 0
 
 
@@ -292,7 +288,7 @@ def test_parser_visitor__validate_type_invalid_type_dont_care(
 ):
     a_visitor._validate_type("ninja", "a", None)
 
-    assert a_visitor.exception is None
+    assert a_visitor.exceptions == []
     assert a_visitor.continue_child == 1
 
 
@@ -347,8 +343,8 @@ def test_parser_visitor__validate_vars_existing_okay_var_is_list_nok(
     a_visitor._validates_vars()
 
     assert a_visitor.continue_child == 0
-    assert a_visitor.exception is not None
-    assert isinstance(a_visitor.exception, TypeError)
+    assert a_visitor.exceptions is not None
+    assert isinstance(a_visitor.exceptions[0], TypeError)
 
 
 def test_parser_visitor__validate_vars_existing_okay_var_has_a_dfv(
@@ -395,8 +391,8 @@ def test_parser_visitor__validate_vars_existing_okay_var_no_dfv_non_nullable(
     a_visitor._validates_vars()
 
     assert a_visitor.continue_child == 0
-    assert a_visitor.exception is not None
-    assert isinstance(a_visitor.exception, UnknownVariableException)
+    assert a_visitor.exceptions is not None
+    assert isinstance(a_visitor.exceptions[0], UnknownVariableException)
 
 
 def test_parser_visitor__on_variable_definition_out(a_visitor, an_element):
@@ -462,8 +458,8 @@ def test_parser_visitor__on_fragment_definition_in_already_know_fragment(
     a_visitor._on_fragment_definition_in(an_element)
 
     assert a_visitor.continue_child == 0
-    assert a_visitor.exception is not None
-    assert isinstance(a_visitor.exception, TartifletteException)
+    assert a_visitor.exceptions is not None
+    assert isinstance(a_visitor.exceptions[0], TartifletteException)
 
 
 def test_parser_visitor__on_fragment_definition_out(a_visitor, an_element):

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -40,15 +40,25 @@ async def test_engine_execute_parse_error(clean_registry):
 
     e = Engine("type Query { a: String }")
 
-    assert await e.execute("query { unknownNode }") == {
+    assert await e.execute("query { unknownNode1 unknownNode2 }") == {
         "data": None,
         "errors": [
             {
-                "message": "field `Query.unknownNode` was not found in GraphQL schema.",
-                "path": ["unknownNode"],
+                "message": "field `Query.unknownNode1` was not found in GraphQL schema.",
+                "path": ["unknownNode1"],
                 "locations": [
                     {
                         "column": 9,
+                        "line": 1,
+                    },
+                ],
+            },
+            {
+                "message": "field `Query.unknownNode2` was not found in GraphQL schema.",
+                "path": ["unknownNode1", "unknownNode2"],
+                "locations": [
+                    {
+                        "column": 22,
                         "line": 1,
                     },
                 ],

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,5 +1,5 @@
 import pytest
-from tartiflette.resolver.factory import default_error_resolver
+from tartiflette.resolver.factory import default_error_coercer
 from unittest.mock import Mock
 
 
@@ -69,15 +69,15 @@ async def test_engine_execute_parse_error(clean_registry):
 
 
 @pytest.mark.asyncio
-async def test_engine_execute_custom_error_resolver(clean_registry):
+async def test_engine_execute_custom_error_coercer(clean_registry):
     from tartiflette.engine import Engine
 
-    def custom_error_resolver(exception):
-        error = default_error_resolver(exception)
+    def custom_error_coercer(exception):
+        error = default_error_coercer(exception)
         error["message"] = error["message"] + "Custom"
         return error
 
-    e = Engine("type Query { a: String }", error_resolver=custom_error_resolver)
+    e = Engine("type Query { a: String }", error_coercer=custom_error_coercer)
 
     assert await e.execute("query { unknownNode1 unknownNode2 }") == {
         "data": None,

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -77,7 +77,7 @@ async def test_engine_execute_empty_req_except(clean_registry):
         "data": None,
         "errors": [
             {
-                "message": "Server encountered an error.",
+                "message": "1.1: syntax error, unexpected EOF",
                 "path": None,
                 "locations": [],
             },
@@ -95,7 +95,7 @@ async def test_engine_execute_syntax_error(clean_registry):
         "data": None,
         "errors": [
             {
-                "message": "Server encountered an error.",
+                "message": "1.12: unrecognized character \\xc2",
                 "path": None,
                 "locations": [],
             },
@@ -117,7 +117,7 @@ async def test_engine_execute_unhandled_exception(clean_registry):
         "data": None,
         "errors": [
             {
-                "message": "Server encountered an error.",
+                "message": "4.20: unrecognized character \\xc2",
                 "path": None,
                 "locations": [],
             },

--- a/tests/unit/types/test_exceptions.py
+++ b/tests/unit/types/test_exceptions.py
@@ -1,0 +1,81 @@
+import pytest
+
+from tartiflette.types.exceptions.tartiflette import GraphQLError
+from tartiflette.types.location import Location
+
+
+@pytest.mark.parametrize("message,init_kwargs,coerce_value_kwargs,expected", [
+    (
+        "Init GraphQLError",
+        {},
+        {},
+        {
+            "message": "Init GraphQLError",
+            "path": None,
+            "locations": [],
+        },
+    ),
+    (
+        "Init GraphQLError",
+        {
+            "path": ["init", "path"],
+            "locations": [
+                Location(line=1, column=1),
+            ],
+            "user_message": "User GraphQLError",
+        },
+        {},
+        {
+            "message": "User GraphQLError",
+            "path": ["init", "path"],
+            "locations": [
+                {"line": 1, "column": 1},
+            ],
+        },
+    ),
+    (
+        "Init GraphQLError",
+        {},
+        {
+            "path": ["coerce", "value", "path"],
+            "locations": [
+                Location(line=2, column=2),
+            ],
+        },
+        {
+            "message": "Init GraphQLError",
+            "path": ["coerce", "value", "path"],
+            "locations": [
+                {"line": 2, "column": 2},
+            ],
+        },
+    ),
+    (
+        "Init GraphQLError",
+        {
+            "path": ["init", "path"],
+            "locations": [
+                Location(line=1, column=1),
+            ],
+            "user_message": "User GraphQLError",
+        },
+        {
+            "path": ["coerce", "value", "path"],
+            "locations": [
+                Location(line=2, column=2),
+            ],
+        },
+        {
+            "message": "User GraphQLError",
+            "path": ["coerce", "value", "path"],
+            "locations": [
+                {"line": 2, "column": 2},
+            ],
+        },
+    ),
+])
+def test_graphqlerror_coerce_value(
+    message, init_kwargs, coerce_value_kwargs, expected
+):
+    graphql_error = GraphQLError(message, **init_kwargs)
+    assert graphql_error.coerce_value(**coerce_value_kwargs) == expected


### PR DESCRIPTION
The goal here is to be able to throw custom exceptions on our resolvers. Those exceptions could override the default `GraphQLError` behavior of `Tartiflette`. The only requirement for those custom exceptions should be to implement a `coerce_value` callable attribute.

This way, we could implement some custom exceptions that could have a custom coerced value:
```python
class BadRequestError(Exception):
    def coerce_value(self, *_args, path=None, locations=None, **_kwargs):
        return {"message": "Bad request", "type": "bad_request"}


@Resolver("Query.hello")
async def resolver_hello(parent, args, ctx, info):
    if args["name"] == "":
        raise BadRequestError("`name` argument shouldn't by empty.")
    return "hello " + args["name"]
```

Following query:
```graphql
query {
  hello(name: "")
}
```

Should result in:
```json
{
  "data": null,
  "errors": [
    {
      "message": "Bad request",
      "type": "bad_request"
    }
  ]
}
```