### PR TITLE
Fix parsing error lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ e = Engine("my_sdl.sdl", error_coercer=my_error_coercer)
 - Avoid `TypeError` by re-raising `UnknownSchemaFieldResolver` or casting `_inline_fragment_type` to string.
 - Raise `GraphQLError` instead of builtin exceptions.
 - ISSUE-70: Now Typecondition is correctly unset for nested fields inside a fragment.
+- ISSUE-71: Now libgraphqlparser parsing errors only lives for the duration of the request.
 
 ## [Release]
 

--- a/tartiflette/parser/cffi/__init__.py
+++ b/tartiflette/parser/cffi/__init__.py
@@ -509,7 +509,7 @@ class LibGraphqlParser:
         self._lib_callbacks = self._ffi.new(
             "struct GraphQLAstVisitorCallbacks *"
         )
-        self._errors = self._ffi.new("char **")
+
         self._callbacks = []
         self._interested_by = {}
         self._default_visitor_cls = Visitor
@@ -573,18 +573,20 @@ class LibGraphqlParser:
         if isinstance(query, str):
             query = query.encode("UTF-8")
 
+        errors = self._ffi.new("char **")
+
         c_query = self._ffi.new("char[]", query)
         parsed_data = _ParsedData(
-            self._lib.graphql_parse_string(c_query, self._errors),
+            self._lib.graphql_parse_string(c_query, errors),
             self._lib.graphql_node_free,
         )
 
-        if self._errors[0] != self._ffi.NULL:
+        if errors[0] != self._ffi.NULL:
             # TODO specialize Exception here
             e = GraphQLError(
-                self._ffi.string(self._errors[0]).decode("UTF-8", "replace")
+                self._ffi.string(errors[0]).decode("UTF-8", "replace")
             )
-            self._lib.graphql_error_free(self._errors[0])
+            self._lib.graphql_error_free(errors[0])
             raise e
 
         return parsed_data

--- a/tests/functional/regressions/test_issue71.py
+++ b/tests/functional/regressions/test_issue71.py
@@ -1,0 +1,81 @@
+import pytest
+
+
+from tartiflette.resolver import Resolver
+from tartiflette.engine import Engine
+
+
+_DATAS = {
+    "repositories": {
+        "edges": [{"node": {"name": "A"}}, {"node": {"name": "b"}}]
+    }
+}
+
+
+@Resolver("Query.viewer", schema_name="test_issue71")
+async def resolver_query_viewer(*_, **__):
+    return _DATAS
+
+
+_TTFTT_ENGINE = Engine(
+    """
+        type RepositoryOwner {
+            login: String
+        }
+
+        type Repository {
+            name: String
+            owner: RepositoryOwner
+        }
+
+        type RepositoryEdge {
+            node: Repository
+        }
+
+        type RepositoryConnection {
+            edges: [RepositoryEdge]!
+        }
+
+        type Viewer {
+            repositories(first: Int = 10): RepositoryConnection
+        }
+
+        type Query {
+            viewer: Viewer
+        }
+    """,
+    schema_name="test_issue71",
+)
+
+
+@pytest.mark.asyncio
+async def test_issue70_fragment_in_inline():
+    query = """
+        query { {}
+    """
+
+    results = await _TTFTT_ENGINE.execute(query)
+    assert results == {
+        "data": None,
+        "errors": [
+            {
+                "locations": [],
+                "message": "2.16: unrecognized character \\xc2",
+                "path": None,
+            }
+        ],
+    }
+    query = """
+        query { viewer { repositories { edges { node { name } } } } }
+    """
+    results = await _TTFTT_ENGINE.execute(query)
+
+    assert results == {
+        "data": {
+            "viewer": {
+                "repositories": {
+                    "edges": [{"node": {"name": "A"}}, {"node": {"name": "b"}}]
+                }
+            }
+        }
+    }


### PR DESCRIPTION
Parsing errors must only live for the duration of the request.
Closes #71 

- [x] Implementation
- [x] Tests
- [x] Changelog Update