### PR TITLE
Improve functional test with a custom pytest marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Added
 
-- Add import sorting on style rule
-- Add formating on tests
-- Add link to tartiflette-aiohttp in readme
+- Add import sorting on style rule.
+- Add formating on tests.
+- Add link to tartiflette-aiohttp in readme.
+- Add a `ttftt_engine` pytest marker to improve the way we handle functional tests.
 
 ### Fixed
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ class BuildPyCmd(build_py):
 
 
 _TEST_REQUIRE = [
-    "pytest",
-    "pytest-cov",
-    "pytest-asyncio",
+    "pytest==4.1.1",
+    "pytest-cov==2.6.1",
+    "pytest-asyncio==0.10.0",
     "pytest-xdist",
     "pylint==2.1.1",
     "xenon",
@@ -57,7 +57,7 @@ _TEST_REQUIRE = [
     "isort",
 ]
 
-_BENCHMARK_REQUIRE = ["pytest-benchmark"]
+_BENCHMARK_REQUIRE = ["pytest-benchmark==3.2.2"]
 
 _VERSION = "0.3.2"
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,9 +7,18 @@ from tartiflette.schema.registry import SchemaRegistry
 
 _CURR_PATH = os.path.dirname(os.path.abspath(__file__))
 
-_DEFAULT_SCHEMA = os.path.join(_CURR_PATH, "data", "sdls", "animals.sdl")
 
-_SCHEMAS = {"default": _DEFAULT_SCHEMA, "animals": _DEFAULT_SCHEMA}
+def _get_sdl_path(*args):
+    return os.path.join(_CURR_PATH, "data", "sdls", *args)
+
+
+_DEFAULT_SCHEMA = _get_sdl_path("animals.sdl")
+
+_SCHEMAS = {
+    "default": _DEFAULT_SCHEMA,
+    "animals": _DEFAULT_SCHEMA,
+    "libraries": _get_sdl_path("libraries.sdl"),
+}
 
 _TTFTT_ENGINES = {
     schema_name: Engine(sdl, schema_name=schema_name)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -2,14 +2,12 @@ import os
 
 import pytest
 
-from tartiflette import Engine
+from tartiflette import Engine, Resolver
 from tartiflette.schema.registry import SchemaRegistry
 
 _CURR_PATH = os.path.dirname(os.path.abspath(__file__))
 
-
 _DEFAULT_SCHEMA = os.path.join(_CURR_PATH, "data", "sdls", "animals.sdl")
-
 
 _SCHEMAS = {"default": _DEFAULT_SCHEMA, "animals": _DEFAULT_SCHEMA}
 
@@ -26,18 +24,59 @@ def clean_registry():
     SchemaRegistry._schemas = {}
 
 
-def pytest_generate_tests(metafunc):
+def _get_ttftt_engine_marker(node):
     try:
-        marker = metafunc.definition.get_closest_marker("ttftt_engine")
-        if not marker:
-            return None
+        return node.get_closest_marker("ttftt_engine")
     except AttributeError:
-        return None
+        pass
+    return None
 
-    engine_name = marker.kwargs.get("name") or "default"
+
+def _get_schema_name_from_marker(marker):
+    return marker.kwargs.get("name") or "default"
+
+
+def pytest_generate_tests(metafunc):
+    marker = _get_ttftt_engine_marker(metafunc.definition)
+    if not marker:
+        return
+
+    schema_name = _get_schema_name_from_marker(marker)
+
     try:
-        engine = _TTFTT_ENGINES[engine_name]
+        engine = _TTFTT_ENGINES[schema_name]
     except KeyError:
         engine = _TTFTT_ENGINES["default"]
 
     metafunc.parametrize("engine", [engine])
+
+
+def pytest_runtest_setup(item):
+    marker = _get_ttftt_engine_marker(item)
+    if not marker:
+        return
+
+    resolvers = marker.kwargs.get("resolvers")
+    if not resolvers:
+        return
+
+    schema_name = _get_schema_name_from_marker(marker)
+
+    # Init schema definitions
+    SchemaRegistry._schemas.setdefault(schema_name, {})
+
+    # Reset schema resolvers
+    SchemaRegistry._schemas[schema_name]["resolvers"] = []
+
+    # Apply "Resolver" decorators to resolvers functions
+    for name, implementation in resolvers.items():
+        Resolver(name, schema_name=schema_name)(implementation)
+
+    # Bake resolvers
+    for resolver in (
+        SchemaRegistry._schemas[schema_name].get("resolvers") or []
+    ):
+        resolver.bake(_TTFTT_ENGINES[schema_name]._schema)
+
+    # Re-bake engine schema
+    _TTFTT_ENGINES[schema_name]._schema.bake()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,6 +1,21 @@
+import os
+
 import pytest
 
+from tartiflette import Engine
 from tartiflette.schema.registry import SchemaRegistry
+
+
+_CURR_PATH = os.path.dirname(os.path.abspath(__file__))
+
+_DEFAULT_ENGINE = Engine(
+    os.path.join(_CURR_PATH, "data", "sdls", "animals.sdl")
+)
+
+_TTFTT_ENGINES = {
+    "default": _DEFAULT_ENGINE,
+    "animals": _DEFAULT_ENGINE,
+}
 
 
 @pytest.yield_fixture
@@ -8,3 +23,20 @@ def clean_registry():
     SchemaRegistry._schemas = {}
     yield SchemaRegistry
     SchemaRegistry._schemas = {}
+
+
+def pytest_generate_tests(metafunc):
+    try:
+        marker = metafunc.definition.get_closest_marker("ttftt_engine")
+        if not marker:
+            return None
+    except AttributeError:
+        return None
+
+    engine_name = marker.kwargs.get("name") or "default"
+    try:
+        engine = _TTFTT_ENGINES[engine_name]
+    except KeyError:
+        engine = _TTFTT_ENGINES["default"]
+
+    metafunc.parametrize("engine", [engine])

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,11 +7,16 @@ from tartiflette.schema.registry import SchemaRegistry
 
 _CURR_PATH = os.path.dirname(os.path.abspath(__file__))
 
-_DEFAULT_ENGINE = Engine(
-    os.path.join(_CURR_PATH, "data", "sdls", "animals.sdl")
-)
 
-_TTFTT_ENGINES = {"default": _DEFAULT_ENGINE, "animals": _DEFAULT_ENGINE}
+_DEFAULT_SCHEMA = os.path.join(_CURR_PATH, "data", "sdls", "animals.sdl")
+
+
+_SCHEMAS = {"default": _DEFAULT_SCHEMA, "animals": _DEFAULT_SCHEMA}
+
+_TTFTT_ENGINES = {
+    schema_name: Engine(sdl, schema_name=schema_name)
+    for schema_name, sdl in _SCHEMAS.items()
+}
 
 
 @pytest.yield_fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -5,17 +5,13 @@ import pytest
 from tartiflette import Engine
 from tartiflette.schema.registry import SchemaRegistry
 
-
 _CURR_PATH = os.path.dirname(os.path.abspath(__file__))
 
 _DEFAULT_ENGINE = Engine(
     os.path.join(_CURR_PATH, "data", "sdls", "animals.sdl")
 )
 
-_TTFTT_ENGINES = {
-    "default": _DEFAULT_ENGINE,
-    "animals": _DEFAULT_ENGINE,
-}
+_TTFTT_ENGINES = {"default": _DEFAULT_ENGINE, "animals": _DEFAULT_ENGINE}
 
 
 @pytest.yield_fixture

--- a/tests/functional/data/sdls/animals.sdl
+++ b/tests/functional/data/sdls/animals.sdl
@@ -1,0 +1,58 @@
+interface Sentient {
+  name: String!
+}
+
+interface Pet {
+  name: String!
+}
+
+enum DogCommand { SIT, DOWN, HEEL }
+enum CatCommand { JUMP }
+
+type Dog implements Pet {
+  name: String!
+  nickname: String
+  barkVolume: Int
+  doesKnowCommand(dogCommand: DogCommand!): Boolean!
+  isHousetrained(atOtherHomes: Boolean): Boolean!
+  owner: Human
+}
+
+type Alien implements Sentient {
+  name: String!
+  homePlanet: String
+}
+
+type Human implements Sentient {
+  name: String!
+}
+
+type Cat implements Pet {
+  name: String!
+  nickname: String
+  doesKnowCommand(catCommand: CatCommand!): Boolean!
+  meowVolume: Int
+}
+
+type MutateDogPayload {
+  id: String
+  dog: Dog
+}
+
+union CatOrDog = Cat | Dog
+union DogOrHuman = Dog | Human
+union HumanOrAlien = Human | Alien
+
+type Query {
+  dog: Dog
+}
+
+type Mutation {
+  mutateDog: MutateDogPayload
+}
+
+type Subscription {
+  newDog: Dog
+  newHuman: Human
+  newAlien: Alien
+}

--- a/tests/functional/data/sdls/libraries.sdl
+++ b/tests/functional/data/sdls/libraries.sdl
@@ -6,13 +6,8 @@ enum BookCategory {
   History
 }
 
-type Query {
-  libraries: [Library]
-}
-
-type Library {
-  books: [Book]
-  authors: [Author]
+enum Status {
+  SUCCESS
 }
 
 type Author {
@@ -24,4 +19,35 @@ type Book {
   author: Author
   price: Float
   category: BookCategory
+}
+
+type Library {
+  books: [Book]
+  authors: [Author]
+}
+
+input AddBookInput {
+  clientMutationId: String
+  title: String!
+  price: Float!
+}
+
+type AddBookPayload {
+  status: Status
+  clientMutationId: String
+  book: Book
+}
+
+type Query {
+  libraries: [Library]
+  books: [Book]
+}
+
+type CustomRootMutation {
+  addBook(input: AddBookInput!): AddBookPayload
+}
+
+schema {
+  query: Query
+  mutation: CustomRootMutation
 }

--- a/tests/functional/data/sdls/libraries.sdl
+++ b/tests/functional/data/sdls/libraries.sdl
@@ -1,0 +1,27 @@
+enum BookCategory {
+  Action
+  Adventure
+  Romance
+  Fiction
+  History
+}
+
+type Query {
+  libraries: [Library]
+}
+
+type Library {
+  books: [Book]
+  authors: [Author]
+}
+
+type Author {
+  name: String
+}
+
+type Book {
+  title: String
+  author: Author
+  price: Float
+  category: BookCategory
+}

--- a/tests/functional/regressions/test_issue86.py
+++ b/tests/functional/regressions/test_issue86.py
@@ -1,50 +1,15 @@
 import pytest
 
-from tartiflette.engine import Engine
 from tartiflette.resolver import Resolver
 
 
-@Resolver("Query.dog", schema_name="test_issue86")
+@Resolver("Query.dog")
 async def resolver_query_viewer(*_, **__):
     return {"dog": {"name": "Dog", "owner": {"name": "Human"}}}
 
 
-_TTFTT_ENGINE = Engine(
-    """
-    interface Sentient {
-      name: String!
-    }
-    
-    interface Pet {
-      name: String!
-    }
-    
-    type Human implements Sentient {
-      name: String!
-    }
-    
-    type Dog implements Pet {
-      name: String!
-      owner: Human
-    }
-    
-    type MutateDogPayload {
-      id: String
-    }
-    
-    type Query {
-      dog: Dog
-    }
-    
-    type Mutation {
-      mutateDog: MutateDogPayload
-    }
-    """,
-    schema_name="test_issue86",
-)
-
-
 @pytest.mark.asyncio
+@pytest.mark.ttftt_engine
 @pytest.mark.parametrize(
     "query,errors",
     [
@@ -156,8 +121,5 @@ _TTFTT_ENGINE = Engine(
         ),
     ],
 )
-async def test_issue86(query, errors):
-    assert await _TTFTT_ENGINE.execute(query) == {
-        "data": None,
-        "errors": errors,
-    }
+async def test_issue86(engine, query, errors):
+    assert await engine.execute(query) == {"data": None, "errors": errors}

--- a/tests/functional/regressions/test_issue86.py
+++ b/tests/functional/regressions/test_issue86.py
@@ -1,15 +1,12 @@
 import pytest
 
-from tartiflette.resolver import Resolver
 
-
-@Resolver("Query.dog")
 async def resolver_query_viewer(*_, **__):
     return {"dog": {"name": "Dog", "owner": {"name": "Human"}}}
 
 
 @pytest.mark.asyncio
-@pytest.mark.ttftt_engine
+@pytest.mark.ttftt_engine(resolvers={"Query.dog": resolver_query_viewer})
 @pytest.mark.parametrize(
     "query,errors",
     [

--- a/tests/functional/regressions/test_issue87.py
+++ b/tests/functional/regressions/test_issue87.py
@@ -1,47 +1,15 @@
 import pytest
 
-from tartiflette.engine import Engine
 from tartiflette.resolver import Resolver
 
 
-@Resolver("Query.dog", schema_name="test_issue87")
+@Resolver("Query.dog")
 async def resolver_query_viewer(*_, **__):
     return {"dog": {"name": "Dog", "owner": {"name": "Human"}}}
 
 
-_TTFTT_ENGINE = Engine(
-    """
-    interface Sentient {
-      name: String!
-    }
-    
-    interface Pet {
-      name: String!
-    }
-    
-    type Human implements Sentient {
-      name: String!
-    }
-    
-    type Dog implements Pet {
-      name: String!
-      owner: Human
-    }
-    
-    type Query {
-      dog: Dog
-    }
-    
-    type Subscription {
-      newDog: Dog
-      newHuman: Human
-    }
-    """,
-    schema_name="test_issue87",
-)
-
-
 @pytest.mark.asyncio
+@pytest.mark.ttftt_engine
 @pytest.mark.parametrize(
     "query,errors",
     [
@@ -152,8 +120,5 @@ _TTFTT_ENGINE = Engine(
         ),
     ],
 )
-async def test_issue87(query, errors):
-    assert await _TTFTT_ENGINE.execute(query) == {
-        "data": None,
-        "errors": errors,
-    }
+async def test_issue87(engine, query, errors):
+    assert await engine.execute(query) == {"data": None, "errors": errors}

--- a/tests/functional/regressions/test_issue87.py
+++ b/tests/functional/regressions/test_issue87.py
@@ -1,15 +1,12 @@
 import pytest
 
-from tartiflette.resolver import Resolver
 
-
-@Resolver("Query.dog")
 async def resolver_query_viewer(*_, **__):
     return {"dog": {"name": "Dog", "owner": {"name": "Human"}}}
 
 
 @pytest.mark.asyncio
-@pytest.mark.ttftt_engine
+@pytest.mark.ttftt_engine(resolvers={"Query.dog": resolver_query_viewer})
 @pytest.mark.parametrize(
     "query,errors",
     [

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -1,96 +1,64 @@
 from collections import namedtuple
-from typing import Any
-from unittest.mock import Mock, call
 
 import pytest
 
 from tartiflette import Resolver
 from tartiflette.engine import Engine
-from tartiflette.executors.types import Info
-from tartiflette.types.location import Location
+
+Library = namedtuple("Library", "books,authors")
+Author = namedtuple("Author", "name")
+Book = namedtuple("Book", "title,author,price,category")
+
+AuthorRudyardKipling = Author("Rudyard Kipling")
+AuthorHarperLee = Author("Harper Lee")
+AuthorLeoTolstoy = Author("Leo Tolstoy")
+AuthorJaneAustin = Author("Jane Austin")
+BookJungleBook = Book(
+    title="The Jungle Book",
+    author=AuthorRudyardKipling,
+    price=14.99,
+    category="Adventure",
+)
+BookToKillAMockingbird = Book(
+    title="To Kill a Mockingbird",
+    author=AuthorHarperLee,
+    price=12.99,
+    category="Fiction",
+)
+BookAnnaKarenina = Book(
+    title="Anna Karenina",
+    author=AuthorLeoTolstoy,
+    price=19.99,
+    category="Fiction",
+)
+BookPrideAndPrejudice = Book(
+    title="Pride and Prejudice",
+    author=AuthorJaneAustin,
+    price=11.99,
+    category="Romance",
+)
+LibraryOne = Library(
+    books=[BookAnnaKarenina, BookJungleBook, BookToKillAMockingbird],
+    authors=[AuthorLeoTolstoy, AuthorHarperLee, AuthorRudyardKipling],
+)
+LibraryTwo = Library(
+    books=[BookPrideAndPrejudice, BookJungleBook],
+    authors=[AuthorJaneAustin, AuthorRudyardKipling],
+)
+
+
+async def func_field_libraries_resolver(*_args, **_kwargs):
+    return [LibraryOne, LibraryTwo]
 
 
 @pytest.mark.asyncio
-async def test_full_query_with_alias(clean_registry):
+@pytest.mark.ttftt_engine(
+    name="libraries",
+    resolvers={"Query.libraries": func_field_libraries_resolver},
+)
+async def test_full_query_with_alias(engine):
     # TODO: Add Union and Interface and NonNull, All scalars Fields.
-    schema_sdl = """
-    enum BookCategory {
-        Action
-        Adventure
-        Romance
-        Fiction
-        History
-    }
-
-    type Query {
-        libraries: [Library]
-    }
-
-    type Library {
-        books: [Book]
-        authors: [Author]
-    }
-
-    type Author {
-        name: String
-    }
-
-    type Book {
-        title: String
-        author: Author
-        price: Float
-        category: BookCategory
-    }
-    """
-
-    Library = namedtuple("Library", "books,authors")
-    Author = namedtuple("Author", "name")
-    Book = namedtuple("Book", "title,author,price,category")
-
-    AuthorRudyardKipling = Author("Rudyard Kipling")
-    AuthorHarperLee = Author("Harper Lee")
-    AuthorLeoTolstoy = Author("Leo Tolstoy")
-    AuthorJaneAustin = Author("Jane Austin")
-    BookJungleBook = Book(
-        title="The Jungle Book",
-        author=AuthorRudyardKipling,
-        price=14.99,
-        category="Adventure",
-    )
-    BookToKillAMockingbird = Book(
-        title="To Kill a Mockingbird",
-        author=AuthorHarperLee,
-        price=12.99,
-        category="Fiction",
-    )
-    BookAnnaKarenina = Book(
-        title="Anna Karenina",
-        author=AuthorLeoTolstoy,
-        price=19.99,
-        category="Fiction",
-    )
-    BookPrideAndPrejudice = Book(
-        title="Pride and Prejudice",
-        author=AuthorJaneAustin,
-        price=11.99,
-        category="Romance",
-    )
-    LibraryOne = Library(
-        books=[BookAnnaKarenina, BookJungleBook, BookToKillAMockingbird],
-        authors=[AuthorLeoTolstoy, AuthorHarperLee, AuthorRudyardKipling],
-    )
-    LibraryTwo = Library(
-        books=[BookPrideAndPrejudice, BookJungleBook],
-        authors=[AuthorJaneAustin, AuthorRudyardKipling],
-    )
-
-    @Resolver("Query.libraries")
-    async def func_field_libraries_resolver(*_args, **_kwargs):
-        return [LibraryOne, LibraryTwo]
-
-    ttftt = Engine(schema_sdl)
-
-    result = await ttftt.execute(
+    result = await engine.execute(
         """
         query TestQueriesFromEnd2End{
             libraries {

--- a/tests/functional/test_queries.py
+++ b/tests/functional/test_queries.py
@@ -1,95 +1,60 @@
 from collections import namedtuple
-from typing import Any
-from unittest.mock import Mock, call
 
 import pytest
 
-from tartiflette import Resolver
-from tartiflette.engine import Engine
-from tartiflette.executors.types import Info
-from tartiflette.types.location import Location
+Library = namedtuple("Library", "books,authors")
+Author = namedtuple("Author", "name")
+Book = namedtuple("Book", "title,author,price,category")
+
+AuthorRudyardKipling = Author("Rudyard Kipling")
+AuthorHarperLee = Author("Harper Lee")
+AuthorLeoTolstoy = Author("Leo Tolstoy")
+AuthorJaneAustin = Author("Jane Austin")
+BookJungleBook = Book(
+    title="The Jungle Book",
+    author=AuthorRudyardKipling,
+    price=14.99,
+    category="Adventure",
+)
+BookToKillAMockingbird = Book(
+    title="To Kill a Mockingbird",
+    author=AuthorHarperLee,
+    price=12.99,
+    category="Fiction",
+)
+BookAnnaKarenina = Book(
+    title="Anna Karenina",
+    author=AuthorLeoTolstoy,
+    price=19.99,
+    category="Fiction",
+)
+BookPrideAndPrejudice = Book(
+    title="Pride and Prejudice",
+    author=AuthorJaneAustin,
+    price=11.99,
+    category="Romance",
+)
+LibraryOne = Library(
+    books=[BookAnnaKarenina, BookJungleBook, BookToKillAMockingbird],
+    authors=[AuthorLeoTolstoy, AuthorHarperLee, AuthorRudyardKipling],
+)
+LibraryTwo = Library(
+    books=[BookPrideAndPrejudice, BookJungleBook],
+    authors=[AuthorJaneAustin, AuthorRudyardKipling],
+)
+
+
+async def func_field_libraries_resolver(*_args, **_kwargs):
+    return [LibraryOne, LibraryTwo]
 
 
 @pytest.mark.asyncio
-async def test_full_query_execute(clean_registry):
-    schema_sdl = """
-    enum BookCategory {
-        Action
-        Adventure
-        Romance
-        Fiction
-        History
-    }
-
-    type Query {
-        libraries: [Library]
-    }
-
-    type Library {
-        books: [Book]
-        authors: [Author]
-    }
-
-    type Author {
-        name: String
-    }
-
-    type Book {
-        title: String
-        author: Author
-        price: Float
-        category: BookCategory
-    }
-    """
-
-    Library = namedtuple("Library", "books,authors")
-    Author = namedtuple("Author", "name")
-    Book = namedtuple("Book", "title,author,price,category")
-
-    AuthorRudyardKipling = Author("Rudyard Kipling")
-    AuthorHarperLee = Author("Harper Lee")
-    AuthorLeoTolstoy = Author("Leo Tolstoy")
-    AuthorJaneAustin = Author("Jane Austin")
-    BookJungleBook = Book(
-        title="The Jungle Book",
-        author=AuthorRudyardKipling,
-        price=14.99,
-        category="Adventure",
-    )
-    BookToKillAMockingbird = Book(
-        title="To Kill a Mockingbird",
-        author=AuthorHarperLee,
-        price=12.99,
-        category="Fiction",
-    )
-    BookAnnaKarenina = Book(
-        title="Anna Karenina",
-        author=AuthorLeoTolstoy,
-        price=19.99,
-        category="Fiction",
-    )
-    BookPrideAndPrejudice = Book(
-        title="Pride and Prejudice",
-        author=AuthorJaneAustin,
-        price=11.99,
-        category="Romance",
-    )
-    LibraryOne = Library(
-        books=[BookAnnaKarenina, BookJungleBook, BookToKillAMockingbird],
-        authors=[AuthorLeoTolstoy, AuthorHarperLee, AuthorRudyardKipling],
-    )
-    LibraryTwo = Library(
-        books=[BookPrideAndPrejudice, BookJungleBook],
-        authors=[AuthorJaneAustin, AuthorRudyardKipling],
-    )
-
-    @Resolver("Query.libraries")
-    async def func_field_libraries_resolver(*_args, **_kwargs):
-        return [LibraryOne, LibraryTwo]
-
-    ttftt = Engine(schema_sdl)
-
-    result = await ttftt.execute(
+@pytest.mark.ttftt_engine(
+    name="libraries",
+    resolvers={"Query.libraries": func_field_libraries_resolver},
+)
+async def test_full_query_execute(engine):
+    result = await engine.execute(
         """
         fragment boby on Author {
             name


### PR DESCRIPTION
This PR introduce a new way to write functional tests by using all the power of `pytest`.

The goal is to declare Tartiflette schemas once at `conftest.py`:
https://github.com/dailymotion/tartiflette/blob/b9de1bd08b08dd03ff0a72a2097ecb4fdadb2026/tests/functional/conftest.py#L17-L21

Each deaclared schemas will generate its own Tartiflette engine. Then, you'll be able to inject those engine on your tests by decorating them with `@pytest.mark.ttftt_engine`.

This marker accepts two optional parameter:
* `name`: which define what schema to use (default is...  `default`)
* `resolvers`: a dict of resolvers to add to the engine

For instance:
```python
# conftest.py
_SCHEMAS = {
    "default": "path/to/my/schema.sdl",
    "custom_engine": "path/to/my/custom/schema.sdl",
}
```

```python
# test_file.py
@pytest.mark.asyncio
@pytest.mark.ttftt_engine
async def test_my_ttftt_engine_decorated_test(engine):
    assert await engine.execute("{ node }") == {
        "data": {"node": None}
    }


def custom_node_resolver(*_args, **_kwargs):
    return "custom node value"


@pytest.mark.asyncio
@pytest.mark.ttftt_engine(
    name="custom_engine",
    resolvers={
        "Query.custom_node": custom_node_resolver,
    },
)
async def test_my_ttftt_engine_decorated_test_with_custom_engine(engine):
    assert await engine.execute("{ custom_node }") == {
        "data": {"custom_node": "custom node value"}
    }
```