### PR TITLE
Add an "initial_value" parameter on the "execute"'s engine method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [ISSUE-119](https://github.com/dailymotion/tartiflette/issues/119): Add an `initial_value` parameter on the `execute`'s engine method.
+
 ## [Released]
 
 ## [0.3.7] - 2019-02-06

--- a/tartiflette/engine.py
+++ b/tartiflette/engine.py
@@ -32,12 +32,15 @@ class Engine:
         operation_name: Optional[str] = None,
         context: Optional[Dict[str, Any]] = None,
         variables: Optional[Dict[str, Any]] = None,
+        initial_value: Optional[Any] = None,
     ) -> dict:
         """
         Parse and execute a GraphQL request (as string).
         :param query: the GraphQL request / query as UTF8-encoded string
+        :param operation_name: the operation name to execute
         :param context: a dict containing anything you need
         :param variables: the variables used in the GraphQL request
+        :param initial_value: an initial value corresponding to the root type being executed
         :return: a GraphQL response (as dict)
         """
         try:
@@ -59,5 +62,6 @@ class Engine:
             operations,
             operation_name,
             request_ctx=context,
+            initial_value=initial_value,
             error_coercer=self._error_coercer,
         )

--- a/tartiflette/executors/basic.py
+++ b/tartiflette/executors/basic.py
@@ -13,15 +13,20 @@ async def _execute(
     root_resolvers: List["NodeField"],
     execution_ctx: ExecutionContext,
     request_ctx: Optional[Dict[str, Any]],
+    initial_value: Optional[Any],
     allow_parallelization: bool,
 ) -> None:
     if not allow_parallelization:
         for resolver in root_resolvers:
-            await resolver(execution_ctx, request_ctx)
+            await resolver(
+                execution_ctx, request_ctx, parent_result=initial_value
+            )
     else:
         await asyncio.gather(
             *[
-                resolver(execution_ctx, request_ctx)
+                resolver(
+                    execution_ctx, request_ctx, parent_result=initial_value
+                )
                 for resolver in root_resolvers
             ],
             return_exceptions=False,
@@ -42,6 +47,7 @@ async def execute(
     operations: Dict[Optional[str], List["NodeOperationDefinition"]],
     operation_name: Optional[str],
     request_ctx: Optional[Dict[str, Any]],
+    initial_value: Optional[Any],
     error_coercer: Callable[[Exception], dict],
 ) -> dict:
     execution_ctx = ExecutionContext()
@@ -69,6 +75,7 @@ async def execute(
         root_nodes,
         execution_ctx,
         request_ctx,
+        initial_value=initial_value,
         allow_parallelization=operation.allow_parallelization,
     )
 

--- a/tests/functional/regressions/test_issue119.py
+++ b/tests/functional/regressions/test_issue119.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+async def _query_human_resolver(parent_result, *_args, **__kwargs):
+    if not parent_result:
+        parent_result = {}
+    return {"name": parent_result.get("name", "Hooman")}
+
+
+@pytest.mark.asyncio
+@pytest.mark.ttftt_engine(resolvers={"Query.human": _query_human_resolver})
+@pytest.mark.parametrize(
+    "query,initial_value,expected",
+    [
+        (
+            """
+            query {
+              human(id: 1) {
+                name
+              }
+            }
+            """,
+            None,
+            {"data": {"human": {"name": "Hooman"}}},
+        ),
+        (
+            """
+            query {
+              human(id: 1) {
+                name
+              }
+            }
+            """,
+            {},
+            {"data": {"human": {"name": "Hooman"}}},
+        ),
+        (
+            """
+            query {
+              human(id: 1) {
+                name
+              }
+            }
+            """,
+            {"name": "Boris"},
+            {"data": {"human": {"name": "Boris"}}},
+        ),
+    ],
+)
+async def test_issue119(engine, query, initial_value, expected):
+    assert await engine.execute(query, initial_value=initial_value) == expected


### PR DESCRIPTION
Closes #119.