### PR TITLE
Apply directives on sub-levels arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Released]
 
+## [0.6.4] - 2019-03-11
+
+### Fixed
+
+- Apply directives on sub-levels arguments.
+
+
 ## [0.6.3] - 2019-03-07
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ _TEST_REQUIRE = [
 
 _BENCHMARK_REQUIRE = ["pytest-benchmark==3.2.2"]
 
-_VERSION = "0.6.3"
+_VERSION = "0.6.4"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 

--- a/tartiflette/types/argument.py
+++ b/tartiflette/types/argument.py
@@ -1,7 +1,12 @@
+from functools import partial
 from typing import Any, Dict, List, Optional, Union
 
 from tartiflette.types.helpers import get_directive_implem_list
 from tartiflette.types.type import GraphQLType
+from tartiflette.utils.arguments import (
+    argument_coercer,
+    surround_with_argument_execution_directives,
+)
 
 
 class GraphQLArgument:
@@ -30,6 +35,7 @@ class GraphQLArgument:
         self._type = {}
         self._schema = schema
         self._directives = directives
+        self.coercer = None
 
         # Introspection Attribute
         self._directives_implementations = None
@@ -58,6 +64,10 @@ class GraphQLArgument:
             and self.default_value == other.default_value
             and self.directives == other.directives
         )
+
+    @property
+    def schema(self) -> "GraphQLSchema":
+        return self._schema
 
     # Introspection Attribute
     @property
@@ -88,3 +98,10 @@ class GraphQLArgument:
         else:
             self._type["name"] = self.gql_type
             self._type["kind"] = self._schema.find_type(self.gql_type).kind
+
+        self.coercer = partial(
+            surround_with_argument_execution_directives(
+                argument_coercer, self.directives
+            ),
+            self,
+        )

--- a/tartiflette/types/input_object.py
+++ b/tartiflette/types/input_object.py
@@ -1,6 +1,5 @@
 from typing import Any, Callable, Dict, List, Optional
 
-from tartiflette.types.argument import GraphQLArgument
 from tartiflette.types.type import GraphQLType
 
 
@@ -17,13 +16,15 @@ class GraphQLInputObjectType(GraphQLType):
     def __init__(
         self,
         name: str,
-        fields: Dict[str, GraphQLArgument],
+        fields: Dict[str, "GraphQLArgument"],
         description: Optional[str] = None,
         schema: Optional["GraphQLSchema"] = None,
     ) -> None:
         super().__init__(name=name, description=description, schema=schema)
         self._fields = fields
-        self._input_fields: List[GraphQLArgument] = list(self._fields.values())
+        self._input_fields: List["GraphQLArgument"] = list(
+            self._fields.values()
+        )
 
     def __repr__(self) -> str:
         return "{}(name={!r}, fields={!r}, description={!r})".format(
@@ -32,6 +33,10 @@ class GraphQLInputObjectType(GraphQLType):
 
     def __eq__(self, other: Any) -> bool:
         return super().__eq__(other) and self._fields == other._fields
+
+    @property
+    def arguments(self) -> Dict[str, "GraphQLArgument"]:
+        return self._fields
 
     # Introspection Attribute
     @property
@@ -42,7 +47,7 @@ class GraphQLInputObjectType(GraphQLType):
     @property
     def inputFields(  # pylint: disable=invalid-name
         self
-    ) -> List[GraphQLArgument]:
+    ) -> List["GraphQLArgument"]:
         return self._input_fields
 
     def bake(

--- a/tartiflette/utils/arguments.py
+++ b/tartiflette/utils/arguments.py
@@ -3,27 +3,13 @@ import asyncio
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional
 
+from tartiflette.types.helpers import reduce_type
+from tartiflette.types.input_object import GraphQLInputObjectType
+
 UNDEFINED_VALUE = object()
 
 
-async def _coerce_argument(
-    argument_definition: "GraphQLArgument",
-    args: Dict[str, Any],
-    ctx: Optional[Dict[str, Any]],
-    info: "Info",
-) -> Any:
-    # pylint: disable=unused-argument
-    try:
-        return args[argument_definition.name].value
-    except KeyError:
-        pass
-
-    if argument_definition.default_value:
-        return argument_definition.default_value
-    return UNDEFINED_VALUE
-
-
-def _surround_with_argument_execution_directives(
+def surround_with_argument_execution_directives(
     func: Callable, directives: List[Dict[str, Any]]
 ) -> Callable:
     for directive in reversed(directives):
@@ -35,6 +21,34 @@ def _surround_with_argument_execution_directives(
     return func
 
 
+async def argument_coercer(argument_definition, args, ctx, info):
+    value = UNDEFINED_VALUE
+    try:
+        value = args[argument_definition.name]
+    except KeyError:
+        pass
+
+    if value is UNDEFINED_VALUE and argument_definition.default_value:
+        value = argument_definition.default_value
+
+    if value is UNDEFINED_VALUE:
+        return value
+
+    try:
+        value = value.value
+    except AttributeError:
+        pass
+
+    schema_type = argument_definition.schema.find_type(
+        reduce_type(argument_definition.gql_type)
+    )
+
+    if not isinstance(schema_type, GraphQLInputObjectType):
+        return value
+
+    return await coerce_arguments(schema_type.arguments, value, ctx, info)
+
+
 async def coerce_arguments(
     argument_definitions: Dict[str, "GraphQLArgument"],
     input_args: Dict[str, Any],
@@ -43,10 +57,7 @@ async def coerce_arguments(
 ) -> Dict[str, Any]:
     results = await asyncio.gather(
         *[
-            # TODO: surround argument with directives at bake time
-            _surround_with_argument_execution_directives(
-                _coerce_argument, argument_definition.directives
-            )(argument_definition, input_args, ctx, info)
+            argument_definition.coercer(input_args, ctx, info)
             for argument_definition in argument_definitions.values()
         ]
     )

--- a/tests/functional/regressions/test_issue133.py
+++ b/tests/functional/regressions/test_issue133.py
@@ -1,11 +1,13 @@
 import logging
 
 from typing import Any, Callable, Dict, Optional
+from unittest.mock import Mock
 
 import pytest
 
 from tartiflette import Engine, Resolver
 from tartiflette.directive import CommonDirective, Directive
+from tartiflette.utils.arguments import UNDEFINED_VALUE
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +38,74 @@ class MaxLengthDirective(CommonDirective):
         return result
 
 
+@Directive("validateChoices", schema_name="test_issue133")
+class ValidateChoicesDirective(CommonDirective):
+    @staticmethod
+    async def on_argument_execution(
+        directive_args: Dict[str, Any],
+        next_directive: Callable,
+        argument_definition: "GraphQLArgument",
+        args: Dict[str, Any],
+        ctx: Optional[Dict[str, Any]],
+        info: "Info",
+    ) -> Any:
+        result = await next_directive(argument_definition, args, ctx, info)
+        if result not in directive_args["choices"]:
+            raise Exception(
+                "Value of argument < %s > on field < %s > is invalid. Valid "
+                "options are < %s >."
+                % (
+                    argument_definition.name,
+                    info.schema_field.name,
+                    ", ".join(directive_args["choices"]),
+                )
+            )
+        return result
+
+
+@Directive("debug", schema_name="test_issue133")
+class DebugDirective(CommonDirective):
+    @staticmethod
+    async def on_argument_execution(
+        directive_args: Dict[str, Any],
+        next_directive: Callable,
+        argument_definition: "GraphQLArgument",
+        args: Dict[str, Any],
+        ctx: Optional[Dict[str, Any]],
+        info: "Info",
+    ) -> Any:
+        return await next_directive(argument_definition, args, ctx, info)
+
+
+@Directive("stop", schema_name="test_issue133")
+class StopDirective(CommonDirective):
+    @staticmethod
+    async def on_argument_execution(
+        directive_args: Dict[str, Any],
+        next_directive: Callable,
+        argument_definition: "GraphQLArgument",
+        args: Dict[str, Any],
+        ctx: Optional[Dict[str, Any]],
+        info: "Info",
+    ) -> Any:
+        return UNDEFINED_VALUE
+
+
 @Resolver("Query.search", schema_name="test_issue133")
 async def _query_search_resolver(parent_result, args, *_, **__):
     return [args["query"]]
+
+
+@Resolver("Query.aField", schema_name="test_issue133")
+async def _query_a_field_resolver(parent_result, args, *_, **__):
+    return "aValue"
+
+
+@Resolver("Query.stopedField", schema_name="test_issue133")
+async def _query_stoped_field_resolver(parent_result, args, *_, **__):
+    return (
+        args.get("stopedArg", {}).get("myInputArg", {}).get("myInputInputArg1")
+    )
 
 
 _SDL = """
@@ -46,10 +113,39 @@ directive @maxLength(
   limit: Int!
 ) on ARGUMENT_DEFINITION
 
+directive @validateChoices(
+  choices: String!
+) on ARGUMENT_DEFINITION
+
+directive @debug on ARGUMENT_DEFINITION
+
+directive @stop on ARGUMENT_DEFINITION
+
+input MyInput {
+  myInputArg: MyInputInput! @debug
+}
+
+input MyStopedInput {
+  myInputArg: MyInputInput! @stop
+}
+
+input MyInputInput {
+  myInputInputArg1: String! @validateChoices(choices: ["VALID"])
+  myInputInputArg2: String! @validateChoices(choices: ["VALID"])
+}
+
 type Query {
   search(
     query: String @maxLength(limit: 10)
   ): [String]
+
+  aField(
+    myArg: MyInput! @debug
+  ): String
+
+  stopedField(
+    stopedArg: MyStopedInput!
+  ): String
 }
 """
 
@@ -78,7 +174,44 @@ _TTFTT_ENGINE = Engine(_SDL, schema_name="test_issue133")
                     }
                 ],
             },
-        )
+        ),
+        (
+            """
+            query {
+              aField(myArg: {
+                myInputArg: {
+                  myInputInputArg1: "INVALID"
+                  myInputInputArg2: "VALID"
+                }
+              })
+            }
+            """,
+            {
+                "data": {"aField": None},
+                "errors": [
+                    {
+                        "message": "Value of argument < myInputInputArg1 > "
+                        "on field < aField > is invalid. Valid options are "
+                        "< VALID >.",
+                        "locations": [{"line": 3, "column": 15}],
+                        "path": ["aField"],
+                    }
+                ],
+            },
+        ),
+        (
+            """
+            query {
+              stopedField(stopedArg: {
+                myInputArg: {
+                  myInputInputArg1: "INVALID"
+                  myInputInputArg2: "VALID"
+                }
+              })
+            }
+            """,
+            {"data": {"stopedField": None}},
+        ),
     ],
 )
 async def test_issue133(query, expected):


### PR DESCRIPTION
Directives on arguments are only applied on the first-level of arguments. If you do have a "complex" arguments composed of `InputObjectType` they will not be applied on them.

The goal if this PR is to fix this behavior and apply directives on each levels.