### PR TITLE
Add errors extensions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [PR-155](https://github.com/dailymotion/tartiflette/pull/155): Add support for `extensions` field in GraphQLError exceptions and allow importing exceptions more easily.
+
 ## [Released]
 
 ## [0.6.5] - 2019-03-12

--- a/tartiflette/types/exceptions/__init__.py
+++ b/tartiflette/types/exceptions/__init__.py
@@ -1,0 +1,1 @@
+from tartiflette.types.exceptions.tartiflette import *

--- a/tartiflette/types/exceptions/__init__.py
+++ b/tartiflette/types/exceptions/__init__.py
@@ -1,1 +1,1 @@
-from tartiflette.types.exceptions.tartiflette import *
+from tartiflette.types.exceptions.tartiflette import GraphQLError

--- a/tartiflette/types/exceptions/tartiflette.py
+++ b/tartiflette/types/exceptions/tartiflette.py
@@ -45,7 +45,7 @@ class GraphQLError(Exception):
             "locations": computed_locations,
         }
         if self.extensions:
-            errors["extensions"] = self.extensions
+            errors["extensions"] = dict(self.extensions)
         return errors
 
 

--- a/tartiflette/types/exceptions/tartiflette.py
+++ b/tartiflette/types/exceptions/tartiflette.py
@@ -12,6 +12,7 @@ class GraphQLError(Exception):
         locations: Optional[List[Location]] = None,
         user_message: str = None,
         more_info: str = "",
+        extensions: Optional[dict] = None,
     ) -> None:
         super().__init__(message)
         self.message = message  # Developer message by default
@@ -19,6 +20,7 @@ class GraphQLError(Exception):
         self.more_info = more_info
         self.path = path or None
         self.locations = locations or []
+        self.extensions = extensions or {}
 
     def coerce_value(
         self,
@@ -35,13 +37,16 @@ class GraphQLError(Exception):
             pass
         except TypeError:
             pass
-        return {
+        errors = {
             "message": self.user_message
             if self.user_message
             else self.message,
             "path": path or self.path,
             "locations": computed_locations,
         }
+        if self.extensions:
+            errors["extensions"] = self.extensions
+        return errors
 
 
 class ImproperlyConfigured(GraphQLError):

--- a/tests/functional/regressions/test_pr155.py
+++ b/tests/functional/regressions/test_pr155.py
@@ -13,7 +13,8 @@ class CustomError(GraphQLError):
 @Resolver("Query.viewer", schema_name="test_pr155")
 async def resolver_query_viewer(*_, **__):
     raise CustomError(
-        "this is an error message", extensions={"code": "custom code"})
+        "this is an error message", extensions={"code": "custom code"}
+    )
 
 
 @Resolver("Query.admin", schema_name="test_pr155")

--- a/tests/functional/regressions/test_pr155.py
+++ b/tests/functional/regressions/test_pr155.py
@@ -1,0 +1,83 @@
+import pytest
+
+from tartiflette.engine import Engine
+from tartiflette.resolver import Resolver
+from tartiflette.types.exceptions import GraphQLError
+
+
+class CustomError(GraphQLError):
+    def __init__(self, message, extensions={}) -> None:
+        super().__init__(message=message, extensions=extensions)
+
+
+@Resolver("Query.viewer", schema_name="test_pr155")
+async def resolver_query_viewer(*_, **__):
+    raise CustomError(
+        "this is an error message", extensions={"code": "custom code"})
+
+
+@Resolver("Query.admin", schema_name="test_pr155")
+async def resolver_query_admin(*_, **__):
+    raise Exception("this is another error message")
+
+
+_TTFTT_ENGINE = Engine(
+    """
+    type User {
+        name: String
+    }
+
+    type Query {
+        viewer: User
+        admin: User
+    }
+    """,
+    schema_name="test_pr155",
+)
+
+
+@pytest.mark.asyncio
+async def test_pr155_custom():
+    query_viewer = """
+    query {
+        viewer {
+            name
+        }
+    }
+    """
+
+    results = await _TTFTT_ENGINE.execute(query_viewer)
+    assert results == {
+        "data": {"viewer": None},
+        "errors": [
+            {
+                "message": "this is an error message",
+                "path": ["viewer"],
+                "locations": [{"line": 3, "column": 9}],
+                "extensions": {"code": "custom code"},
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_pr155_normal():
+    query_admin = """
+    query {
+        admin {
+            name
+        }
+    }
+    """
+
+    results = await _TTFTT_ENGINE.execute(query_admin)
+    assert results == {
+        "data": {"admin": None},
+        "errors": [
+            {
+                "message": "this is another error message",
+                "path": ["admin"],
+                "locations": [{"line": 3, "column": 9}],
+            }
+        ],
+    }

--- a/tests/unit/types/test_exceptions.py
+++ b/tests/unit/types/test_exceptions.py
@@ -57,6 +57,25 @@ from tartiflette.types.location import Location
                 "locations": [{"line": 2, "column": 2}],
             },
         ),
+        (
+            "Init GraphQLError",
+            {
+                "path": ["init", "path"],
+                "locations": [Location(line=1, column=1)],
+                "user_message": "User GraphQLError",
+                "extensions": {"code": 123},
+            },
+            {
+                "path": ["coerce", "value", "path"],
+                "locations": [Location(line=2, column=2)],
+            },
+            {
+                "message": "User GraphQLError",
+                "path": ["coerce", "value", "path"],
+                "locations": [{"line": 2, "column": 2}],
+                "extensions": {"code": 123},
+            },
+        ),
     ],
 )
 def test_graphqlerror_coerce_value(


### PR DESCRIPTION
Hey guys, as discussed on Slack here is a proposal to add support for the `extensions` field on errors and simplify exceptions import & usage.

From the commit log:

the spec allows for an 'extensions' field on response errors:
https://github.com/facebook/graphql/blob/master/spec/Section%207%20--%20Response.md#errors

this adds this field into the generic GraphQLError exception so that
users can simply add their own extended information to their error exceptions

example usage:

```
from tartiflette.types.exceptions import GraphQLError

class WebserviceError(GraphQLError):
    def __init__(self, message, extensions={}) -> None:
        super().__init__(
            message=message,
            extensions=extensions
        )
```