### PR TITLE
Docs: fix name of query resolver functions

### DIFF
--- a/docs/tutorial/write-your-resolvers.md
+++ b/docs/tutorial/write-your-resolvers.md
@@ -49,7 +49,7 @@ from recipes_manager.data import INGREDIENTS_QUANTITY, RECIPES
 
 
 @Resolver("Query.recipes")
-async def resolver_recipe(parent, args, ctx, info):
+async def resolver_recipes(parent, args, ctx, info):
     return RECIPES
 
 
@@ -64,7 +64,7 @@ async def resolver_recipe(parent, args, ctx, info):
 
 
 @Resolver("Recipe.ingredientsQuantity")
-async def resolver_recipe(parent, args, ctx, info):
+async def resolver_ingredients(parent, args, ctx, info):
     if parent and parent["id"] in INGREDIENTS_QUANTITY:
         return INGREDIENTS_QUANTITY[parent["id"]]
 


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/dailymotion/tartiflette) and create your branch from `master` so that it can be merged easily.
* [x] Update CHANGELOG.md with your change (include reference to the issue & this PR).
* [x] Make sure all of the significant new logic is covered by tests.
* [x] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/dailymotion/tartiflette/blob/master/docs/CONTRIBUTING.md)*

---

All resolver functions were named the same in the query resolvers code snippet. I realized this when pylint complained and I don't think it was intentional. :-)