### PR TITLE
Docs: rename 'ingredients quantity' to 'ingredients'

### DIFF
--- a/docs/tutorial/create-server.md
+++ b/docs/tutorial/create-server.md
@@ -28,7 +28,7 @@ enum IngredientType {
     UNIT
 }
 
-type IngredientQuantity {
+type Ingredient {
     name: String!
     quantity: Float!
     type: IngredientType!
@@ -37,7 +37,7 @@ type IngredientQuantity {
 type Recipe {
   id: Int
   name: String
-  ingredientsQuantity: [IngredientQuantity]
+  ingredients: [Ingredient]
   cookingTime: Int
 }
 ```

--- a/docs/tutorial/extend-with-directives.md
+++ b/docs/tutorial/extend-with-directives.md
@@ -16,7 +16,7 @@ directive @deprecated(
 type Recipe {
   id: Int
   name: String
-  ingredientsQuantity: [IngredientQuantity]
+  ingredients: [Ingredient]
   cookingTime: Int
   title: String @deprecated(reason: "Use `name` instead.")
 }

--- a/docs/tutorial/project-initialization.md
+++ b/docs/tutorial/project-initialization.md
@@ -98,7 +98,7 @@ Fill the file **recipes_manager/data.py** with this data.
 ```python
 # Dictionary which contains the ingredients based on the
 # Recipe ID as the key.
-INGREDIENTS_QUANTITY = {
+INGREDIENTS = {
     1: [
         { "name": "potato", "quantity": 10, "type": "UNIT" },
         { "name": "onion", "quantity": 2, "type": "UNIT" },

--- a/docs/tutorial/running-a-query.md
+++ b/docs/tutorial/running-a-query.md
@@ -36,7 +36,7 @@ query {
     id
     name
     cookingTime
-    ingredientsQuantity {
+    ingredients {
       name
       quantity
       type
@@ -57,7 +57,7 @@ Below, a request to select only one recipe, by its `id`.
     id
     name
     cookingTime
-    ingredientsQuantity {
+    ingredients {
       name
       quantity
       type

--- a/docs/tutorial/write-your-mutation-resolvers.md
+++ b/docs/tutorial/write-your-mutation-resolvers.md
@@ -37,7 +37,7 @@ import collections
 
 from tartiflette import Resolver
 
-from recipes_manager.data import INGREDIENTS_QUANTITY, RECIPES
+from recipes_manager.data import RECIPES
 
 
 @Resolver("Mutation.updateRecipe")

--- a/docs/tutorial/write-your-resolvers.md
+++ b/docs/tutorial/write-your-resolvers.md
@@ -37,7 +37,7 @@ If you want to know more about the Resolver part, we suggest taking a look at [t
 In our example, we will have 3 different resolvers.
 * One which will resolve the recipes list: `@Resolver("Query.recipes")`
 * Another which will resolve only one recipe: `@Resolver("Query.recipe")`
-* A last one which will resolve a subfield of the `Recipe` object, the ingredients quantity: `@Resolver("Recipe.ingredientsQuantity")`
+* A last one which will resolve a subfield of the `Recipe` object, the ingredients: `@Resolver("Recipe.ingredients")`
 
 **filename: recipes_manager/query_resolvers.py**
 ```python
@@ -45,7 +45,7 @@ import collections
 
 from tartiflette import Resolver
 
-from recipes_manager.data import INGREDIENTS_QUANTITY, RECIPES
+from recipes_manager.data import INGREDIENTS, RECIPES
 
 
 @Resolver("Query.recipes")
@@ -63,10 +63,10 @@ async def resolver_recipe(parent, args, ctx, info):
     return recipe[0]
 
 
-@Resolver("Recipe.ingredientsQuantity")
-async def resolver_recipe(parent, args, ctx, info):
-    if parent and parent["id"] in INGREDIENTS_QUANTITY:
-        return INGREDIENTS_QUANTITY[parent["id"]]
+@Resolver("Recipe.ingredients")
+async def resolver_ingredients(parent, args, ctx, info):
+    if parent and parent["id"] in INGREDIENTS:
+        return INGREDIENTS[parent["id"]]
 
     return None
 


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/dailymotion/tartiflette) and create your branch from `master` so that it can be merged easily.
* [x] Update CHANGELOG.md with your change (include reference to the issue & this PR).
* [x] Make sure all of the significant new logic is covered by tests.
* [x] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/dailymotion/tartiflette/blob/master/docs/CONTRIBUTING.md)*

The tutorial references "ingredients quantity" which I think is quite confusing: currently, an ingredient quantity has an ID, a name and a *quantity*… This PR suggests to simply use "ingredients".

May conflict with #166 b/c of the new function resolver name.