### PR TITLE
Run the documentation website locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Next]
 
+#### Added
+
+- [ISSUE-165](https://github.com/dailymotion/tartiflette/issues/165): Add the ability to launch the documentation website locally with the `/docs` folder, to simplify the contributing process for the documentation.
+
 #### Changed
 
 - [ISSUE-160](https://github.com/dailymotion/tartiflette/issues/160): All schema definitions errors are returned all at once.

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,7 @@ set-version:
 ifneq ($(SET_ALPHA_VERSION), 0)
 	bash -c "sed -i \"s@_VERSION[ ]*=[ ]*[\\\"\'][0-9]\+\\.[0-9]\+\\.[0-9]\+[\\\"\'].*@_VERSION = \\\"$(PKG_VERSION)\\\"@\" setup.py"
 endif
+
+.PHONY: run-docs
+run-docs:
+	docker-compose up docs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [Read this blogpost about our motivations](https://medium.com/dailymotion/tartiflette-graphql-api-engine-python-open-source-a200c5bbc477)
 TL; DR
-We reached the limit of Graphene, we wanted to build something which met certain requirements:
+We reached the limits of Graphene, we wanted to build something which met certain requirements:
 * **Offers a better developer experience** that respects the Python mindset
 * **Uses SDL** _(Schema Definition Language)_
 * Uses **asyncio** as the sole execution engine
@@ -127,6 +127,27 @@ web.run_app(
 
 * [Milestone 1 _(Released)_](/docs/roadmaps/milestone-1.md) 
 * [Milestone 2 - **Work in progress**](/docs/roadmaps/milestone-2.md)
+
+## How to contribute to the documentation?
+
+As you may know, the documentation is hosted on https://tartiflette.io. This _fabulous_ website is built thanks to another amazing tool, [docusaurus](https://docusaurus.io/).
+
+The content of the documentation is hosted in this repository, to be as close as possible to the code. You will find everything you need/want in the folder `/docs`.
+
+### How to run the website locally?
+
+We built a docker image for the documentation _(dailymotion/tartiflette.io on docker hub)_, which allow us to provide you an easy way to launch the documentation locally, without installing a specific version of node.
+
+**prerequisite**:
+- Docker
+- Docker Compose
+- Make
+
+```bash
+make run-docs
+```
+
+Every change you will make in the `/docs` folder will be automatically hot reloaded. :tada:
 
 ## Known issues
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  docs:
+    image: dailymotion/tartiflette.io:latest
+    ports:
+      - 3000:3000
+      - 35729:35729
+    volumes:
+      - ./docs:/app/docs


### PR DESCRIPTION
Add the ability to launch the documentation website locally with the `/docs` folder, to simplify the contributing process for the documentation.

Only one command to launch the documentation on `http://localhost:3000`

```bash
make run-docs
```

ISSUE #165

* [X] Update CHANGELOG.md with your change (include reference to the issue & this PR).
* [X] Make sure all of the significant new logic is covered by tests.
* [X] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/dailymotion/tartiflette/blob/master/docs/CONTRIBUTING.md)*
