### PR TITLE
Executable directives on fields only wraps field resolvers at execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Released]
 
+- [0.8.x]
+  - [0.8.0](./changelogs/0.8.0.md) - 2019-04-11
 - [0.7.x]
   - [0.7.1](./changelogs/0.7.1.md) - 2019-04-04
   - [0.7.0](./changelogs/0.7.0.md) - 2019-04-02

--- a/changelogs/0.8.0.md
+++ b/changelogs/0.8.0.md
@@ -1,0 +1,4 @@
+# [0.8.0]
+
+## Fixed
+- Executable directives on fields now wraps fields resolvers at execution [#199](https://github.com/dailymotion/tartiflette/issues/199)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ _TEST_REQUIRE = [
 
 _BENCHMARK_REQUIRE = ["pytest-benchmark==3.2.2"]
 
-_VERSION = "0.7.3"
+_VERSION = "0.8.0"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 

--- a/tartiflette/parser/nodes/field.py
+++ b/tartiflette/parser/nodes/field.py
@@ -40,6 +40,7 @@ class NodeField(Node):
         self.alias = alias or self.name
         self.subscribe = subscribe
         self.is_execution_stopped = False
+        self.execution_directives = []
 
     @property
     def cant_be_null(self) -> bool:
@@ -56,7 +57,7 @@ class NodeField(Node):
     def add_directive(
         self, directive: Dict[str, Union["Directive", Dict[str, Any]]]
     ):
-        self.field_executor.add_directive(directive)
+        self.execution_directives.append(directive)
 
     def bubble_error(self) -> None:
         if self.cant_be_null is False:
@@ -172,6 +173,7 @@ class NodeField(Node):
                     location=self.location,
                     execution_ctx=execution_ctx,
                 ),
+                execution_directives=self.execution_directives,
             )
         except SkipExecution:
             self.is_execution_stopped = True

--- a/tests/functional/regressions/test_issue199.py
+++ b/tests/functional/regressions/test_issue199.py
@@ -1,0 +1,293 @@
+import pytest
+
+from tartiflette import Engine, Resolver
+
+
+@Resolver("Query.lists", schema_name="test_skip_include")
+async def resolve_query_lists(*_):
+    return {}
+
+
+@Resolver("ListContainer.listA", schema_name="test_skip_include")
+@Resolver("ListContainer.listB", schema_name="test_skip_include")
+@Resolver("ListContainer.listC", schema_name="test_skip_include")
+@Resolver("ListContainer.listD", schema_name="test_skip_include")
+async def resolve_list_container_list(*_):
+    return [str(i) for i in range(2)]
+
+
+_SDL = """
+type ListContainer {
+  listA: [String]
+  listB: [String]
+  listC: [String]
+  listD: [String]
+}
+
+type Query {
+  lists: ListContainer
+}
+"""
+
+
+_TTFTT_ENGINE = Engine(_SDL, schema_name="test_skip_include")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        # Skip
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listC": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB @skip(if: true)
+                listC
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listC": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA @skip(if: true)
+                listB @skip(if: true)
+                listC
+                listD
+              }
+            }
+            """,
+            {"data": {"lists": {"listC": ["0", "1"], "listD": ["0", "1"]}}},
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC
+                listD @skip(if: true)
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listC": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listC": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC @skip(if: true)
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        # Include
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listC": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB @include(if: false)
+                listC
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listC": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA @include(if: false)
+                listB @include(if: false)
+                listC
+                listD
+              }
+            }
+            """,
+            {"data": {"lists": {"listC": ["0", "1"], "listD": ["0", "1"]}}},
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC
+                listD @include(if: false)
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listC": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listC": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+        (
+            """
+            query {
+              lists {
+                listA
+                listB
+                listC @include(if: false)
+                listD
+              }
+            }
+            """,
+            {
+                "data": {
+                    "lists": {
+                        "listA": ["0", "1"],
+                        "listB": ["0", "1"],
+                        "listD": ["0", "1"],
+                    }
+                }
+            },
+        ),
+    ],
+)
+async def test_skip_include(query, expected):
+    result = await _TTFTT_ENGINE.execute(query)
+    # print()
+    # print()
+    # print(expected)
+    # print()
+    # print(result)
+    # print()
+    # print()
+    assert result == expected

--- a/tests/functional/regressions/test_issue199.py
+++ b/tests/functional/regressions/test_issue199.py
@@ -282,12 +282,4 @@ _TTFTT_ENGINE = Engine(_SDL, schema_name="test_skip_include")
     ],
 )
 async def test_skip_include(query, expected):
-    result = await _TTFTT_ENGINE.execute(query)
-    # print()
-    # print()
-    # print(expected)
-    # print()
-    # print(result)
-    # print()
-    # print()
-    assert result == expected
+    assert await _TTFTT_ENGINE.execute(query) == expected

--- a/tests/unit/resolver/test_factory.py
+++ b/tests/unit/resolver/test_factory.py
@@ -208,35 +208,42 @@ def test_resolverexecutor_bake(
     )
 
     schema_field = Mock(schema=None)
+    schema_field.directives = Mock()
     schema_field.subscribe = Mock() if is_subscription else None
 
     with patch(
         "tartiflette.resolver.factory.default_subscription_resolver",
         wraps=default_subscription_resolver,
     ) as default_subscription_resolver_mock:
-        resolver_executor = _ResolverExecutor(default_resolver, schema_field)
-        resolver_executor.update_coercer = Mock()
-        resolver_executor.update_func = Mock(
-            wraps=resolver_executor.update_func
-        )
-        resolver_executor.apply_directives = Mock()
-
-        resolver_executor.bake(custom_default_resolver)
-
-        resolver_executor.update_coercer.assert_called_once()
-
-        if update_func_called:
-            resolver_executor.update_func.assert_called_once_with(
-                custom_default_resolver
+        with patch(
+            "tartiflette.resolver.factory._surround_with_execution_directives",
+        ) as surround_with_execution_directives_mock:
+            resolver_executor = _ResolverExecutor(
+                default_resolver, schema_field
             )
-        else:
-            resolver_executor.update_func.assert_not_called()
-
-        if default_subscription_resolver_called:
-            default_subscription_resolver_mock.assert_called_once_with(
-                default_resolver
+            resolver_executor.update_coercer = Mock()
+            resolver_executor.update_func = Mock(
+                wraps=resolver_executor.update_func
             )
-        else:
-            default_subscription_resolver_mock.assert_not_called()
 
-        resolver_executor.apply_directives.assert_called_once()
+            resolver_executor.bake(custom_default_resolver)
+
+            resolver_executor.update_coercer.assert_called_once()
+
+            if update_func_called:
+                resolver_executor.update_func.assert_called_once_with(
+                    custom_default_resolver
+                )
+            else:
+                resolver_executor.update_func.assert_not_called()
+
+            if default_subscription_resolver_called:
+                default_subscription_resolver_mock.assert_called_once_with(
+                    default_resolver
+                )
+            else:
+                default_subscription_resolver_mock.assert_not_called()
+
+            surround_with_execution_directives_mock.assert_called_once_with(
+                resolver_executor._raw_func, schema_field.directives
+            )

--- a/tests/unit/resolver/test_factory.py
+++ b/tests/unit/resolver/test_factory.py
@@ -216,7 +216,7 @@ def test_resolverexecutor_bake(
         wraps=default_subscription_resolver,
     ) as default_subscription_resolver_mock:
         with patch(
-            "tartiflette.resolver.factory._surround_with_execution_directives",
+            "tartiflette.resolver.factory._surround_with_execution_directives"
         ) as surround_with_execution_directives_mock:
             resolver_executor = _ResolverExecutor(
                 default_resolver, schema_field

--- a/tests/unit/resolver/test_factory__resolver_executor.py
+++ b/tests/unit/resolver/test_factory__resolver_executor.py
@@ -90,9 +90,7 @@ async def test_resolver_factory__resolver_executor___call__(
         new_callable=AsyncMock,
         return_value={"AB": "M2B"},
     ) as coerce_arguments_mock:
-        r, c = await _resolver_executor_mock(
-            p_r, arg_mock, req_ctx, info, []
-        )
+        r, c = await _resolver_executor_mock(p_r, arg_mock, req_ctx, info, [])
         coerce_arguments_mock.assert_called_once_with(
             {}, arg_mock, req_ctx, info
         )
@@ -158,7 +156,7 @@ def test_resolver_factory__resolver_executor_update_bake(
     _resolver_executor_mock.update_coercer = Mock()
 
     with patch(
-        "tartiflette.resolver.factory._surround_with_execution_directives",
+        "tartiflette.resolver.factory._surround_with_execution_directives"
     ) as surround_with_execution_directives_mock:
         assert _resolver_executor_mock.bake(None) is None
         _resolver_executor_mock.update_coercer.assert_called_once()

--- a/tests/unit/resolver/test_factory__resolver_executor.py
+++ b/tests/unit/resolver/test_factory__resolver_executor.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from tartiflette.types.exceptions.tartiflette import MultipleException
 from tests.unit.utils import AsyncMock
 
 
@@ -15,14 +14,14 @@ def test_resolver_factory__resolver_executor_instance():
 
     res_ex = _ResolverExecutor("A", field)
     assert res_ex._raw_func == "A"
-    assert res_ex._func == "A"
+    assert res_ex._directivated_func == "A"
     assert res_ex._schema_field is field
     assert res_ex._coercer is None
     assert not res_ex._shall_produce_list
 
     res_ex = _ResolverExecutor("A", field)
     assert res_ex._raw_func == "A"
-    assert res_ex._func == "A"
+    assert res_ex._directivated_func == "A"
     assert res_ex._schema_field is field
     assert res_ex._coercer is None
     assert not res_ex._shall_produce_list
@@ -91,14 +90,16 @@ async def test_resolver_factory__resolver_executor___call__(
         new_callable=AsyncMock,
         return_value={"AB": "M2B"},
     ) as coerce_arguments_mock:
-        r, c = await _resolver_executor_mock(p_r, arg_mock, req_ctx, info)
+        r, c = await _resolver_executor_mock(
+            p_r, arg_mock, req_ctx, info, []
+        )
         coerce_arguments_mock.assert_called_once_with(
             {}, arg_mock, req_ctx, info
         )
         assert r == "aResult"
         assert c == "LOL"
 
-    assert _resolver_executor_mock._func.call_args_list == [
+    assert _resolver_executor_mock._directivated_func.call_args_list == [
         ((p_r, {"AB": "M2B"}, req_ctx, info),)
     ]
     assert _resolver_executor_mock._coercer.call_args_list == [
@@ -106,7 +107,7 @@ async def test_resolver_factory__resolver_executor___call__(
     ]
 
     info.execution_ctx.is_introspection = True
-    r, c = await _resolver_executor_mock(p_r, args, req_ctx, info)
+    r, c = await _resolver_executor_mock(p_r, args, req_ctx, info, [])
 
     assert _resolver_executor_mock._introspection.call_args_list == [
         (("aResult", req_ctx, info),)
@@ -115,46 +116,20 @@ async def test_resolver_factory__resolver_executor___call__(
     async def a_raising_func(*args, **kwargs):
         raise Exception("A")
 
-    _resolver_executor_mock._func = a_raising_func
+    _resolver_executor_mock._directivated_func = a_raising_func
 
-    r, c = await _resolver_executor_mock(p_r, args, req_ctx, info)
+    r, c = await _resolver_executor_mock(p_r, args, req_ctx, info, [])
     assert isinstance(r, Exception)
     assert c is None
-
-
-def test_resolver_factory__resolver_executor_apply_directives(
-    _resolver_executor_mock
-):
-    _resolver_executor_mock._schema_field.directives = ["B"]
-
-    with patch(
-        "tartiflette.resolver.factory._surround_with_execution_directives",
-        return_value="LOL",
-    ) as mocked_ex:
-        assert _resolver_executor_mock.apply_directives() is None
-        assert mocked_ex.call_args_list == [
-            (
-                (
-                    _resolver_executor_mock._raw_func,
-                    _resolver_executor_mock._schema_field.directives,
-                ),
-            )
-        ]
-        assert _resolver_executor_mock._func == "LOL"
-
-    del _resolver_executor_mock._schema_field.directives
-
-    assert _resolver_executor_mock.apply_directives() is None
-    assert _resolver_executor_mock._func is _resolver_executor_mock._raw_func
 
 
 def test_resolver_factory__resolver_executor_update_func(
     _resolver_executor_mock
 ):
-    assert _resolver_executor_mock._func is not "g"
+    assert _resolver_executor_mock._directivated_func is not "g"
     assert _resolver_executor_mock._raw_func is not "g"
     assert _resolver_executor_mock.update_func("g") is None
-    assert _resolver_executor_mock._func is not "g"
+    assert _resolver_executor_mock._directivated_func is not "g"
     assert _resolver_executor_mock._raw_func == "g"
 
 
@@ -181,27 +156,29 @@ def test_resolver_factory__resolver_executor_update_bake(
     _resolver_executor_mock._schema_field.subscribe = None
     _resolver_executor_mock.update_func = Mock()
     _resolver_executor_mock.update_coercer = Mock()
-    _resolver_executor_mock.apply_directives = Mock()
 
-    assert _resolver_executor_mock.bake(None) is None
-    _resolver_executor_mock.update_coercer.assert_called_once()
-    _resolver_executor_mock.apply_directives.assert_called_once()
-    assert not _resolver_executor_mock.update_func.called
-    assert _resolver_executor_mock._raw_func is not "T"
+    with patch(
+        "tartiflette.resolver.factory._surround_with_execution_directives",
+    ) as surround_with_execution_directives_mock:
+        assert _resolver_executor_mock.bake(None) is None
+        _resolver_executor_mock.update_coercer.assert_called_once()
+        surround_with_execution_directives_mock.assert_called_once()
+        assert not _resolver_executor_mock.update_func.called
+        assert _resolver_executor_mock._raw_func is not "T"
 
-    assert _resolver_executor_mock.bake("T") is None
-    assert not _resolver_executor_mock.update_func.called
-    assert _resolver_executor_mock._raw_func is not "T"
+        assert _resolver_executor_mock.bake("T") is None
+        assert not _resolver_executor_mock.update_func.called
+        assert _resolver_executor_mock._raw_func is not "T"
 
-    _resolver_executor_mock._raw_func = default_resolver
+        _resolver_executor_mock._raw_func = default_resolver
 
-    assert _resolver_executor_mock.bake(None) is None
-    assert not _resolver_executor_mock.update_func.called
-    assert _resolver_executor_mock._raw_func is not "T"
-    assert _resolver_executor_mock._raw_func is default_resolver
+        assert _resolver_executor_mock.bake(None) is None
+        assert not _resolver_executor_mock.update_func.called
+        assert _resolver_executor_mock._raw_func is not "T"
+        assert _resolver_executor_mock._raw_func is default_resolver
 
-    assert _resolver_executor_mock.bake("T") is None
-    assert _resolver_executor_mock.update_func.called
+        assert _resolver_executor_mock.bake("T") is None
+        assert _resolver_executor_mock.update_func.called
 
 
 def test_resolver_factory__resolver_executor_update_prop_schema_field(

--- a/tests/unit/types/test_field.py
+++ b/tests/unit/types/test_field.py
@@ -16,7 +16,7 @@ def test_graphql_field_init():
     assert field.name == "Name"
     assert field.gql_type == "Test"
     assert field.arguments == OrderedDict([("test", 42), ("another", 24)])
-    assert field.resolver._func is default_resolver
+    assert field.resolver._directivated_func is default_resolver
     assert field.description == "description"
 
 


### PR DESCRIPTION
Closes #199.