### PR TITLE
Error handling: change the 'error_coercer' signature

### DIFF
--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,47 @@
+# [0.9.0] - 2019-04-30
+
+## Changed
+
+The `error_coercer` signature changed from `Callable[[Exception]] -> dict` to `Callable[[Exception], dict] -> dict`.
+
+The main idea of this change is to avoid calling the coerce_value ourselves within our own error_coercer implementation, as this call can be executed by the engine.
+
+Here are 2 examples of a custom error_coercer, the first one with the old way and the second one with the new way.
+
+*Old way*
+```python
+from myvender import CustomException
+from tartiflette.engine import Engine
+from tartiflette.resolver.factory import default_error_coercer
+
+def my_custom_error_coercer(exception):
+    error = default_error_coercer(exception)
+
+    if isinstance(exception, CustomException):
+        error["customfield"] = "blabla"
+
+    return error
+
+engine = Engine(
+    # parameters ...
+    error_coercer=my_custom_error_coercer
+)
+```
+
+**New way**
+```python
+from myvender import CustomException
+from tartiflette.engine import Engine
+from tartiflette.resolver.factory import default_error_coercer
+
+def my_custom_error_coercer(exception, error):
+    if isinstance(exception, CustomException):
+        error["customfield"] = "blabla"
+
+    return error
+
+engine = Engine(
+    # parameters ...
+    error_coercer=my_custom_error_coercer
+)
+```

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ _TEST_REQUIRE = [
 
 _BENCHMARK_REQUIRE = ["pytest-benchmark==3.2.2"]
 
-_VERSION = "0.8.9"
+_VERSION = "0.9.0"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 

--- a/tartiflette/engine.py
+++ b/tartiflette/engine.py
@@ -6,7 +6,10 @@ from tartiflette.executors.basic import (
     subscribe as basic_subscribe,
 )
 from tartiflette.parser import TartifletteRequestParser
-from tartiflette.resolver.factory import default_error_coercer
+from tartiflette.resolver.factory import (
+    default_error_coercer,
+    error_coercer_factory,
+)
 from tartiflette.schema.bakery import SchemaBakery
 from tartiflette.schema.registry import SchemaRegistry
 from tartiflette.types.exceptions.tartiflette import GraphQLError
@@ -40,7 +43,7 @@ class Engine:
 
         Keyword Arguments:
             schema_name {str} -- The name of the SDL (default: {"default"})
-            error_coercer {Callable[[Exception], dict]} -- An optional callable in charge of transforming an Exception into an error dict (default: {default_error_coercer})
+            error_coercer {Callable[[Exception, dict], dict]} -- An optional callable in charge of transforming a couple Exception/error into an error dict (default: {default_error_coercer})
             custom_default_resolver {Optional[Callable]} -- An optional callable that will replace the tartiflette default_resolver (Will be called like a resolver for each UNDECORATED field) (default: {None})
             exclude_builtins_scalars {Optional[List[str]]} -- An optional list of string containing the names of the builtin scalar you don't want to be automatically included, usually it's Date, DateTime or Time scalars (default: {None})
             modules {Optional[Union[str, List[str]]]} -- An optional list of string containing the name of the modules you want the engine to import, usually this modules contains your Resolvers, Directives, Scalar or Subscription code (default: {None})
@@ -51,7 +54,7 @@ class Engine:
 
         self._modules = _import_modules(modules)
 
-        self._error_coercer = error_coercer
+        self._error_coercer = error_coercer_factory(error_coercer)
         self._parser = TartifletteRequestParser()
         SchemaRegistry.register_sdl(schema_name, sdl, exclude_builtins_scalars)
         self._schema = SchemaBakery.bake(

--- a/tartiflette/resolver/factory.py
+++ b/tartiflette/resolver/factory.py
@@ -181,8 +181,17 @@ async def default_resolver(
     return None
 
 
-def default_error_coercer(exception: Exception) -> dict:
-    return exception.coerce_value()
+def default_error_coercer(exception: Exception, error: dict) -> dict:
+    # pylint: disable=unused-argument
+    return error
+
+
+def error_coercer_factory(error_coercer: Callable) -> dict:
+    def func_wrapper(exception: Exception) -> dict:
+        error = exception.coerce_value()
+        return error_coercer(exception, error)
+
+    return func_wrapper
 
 
 class ResolverExecutorFactory:

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -66,8 +66,7 @@ async def test_engine_execute_parse_error(clean_registry):
 async def test_engine_execute_custom_error_coercer(clean_registry):
     from tartiflette.engine import Engine
 
-    def custom_error_coercer(exception):
-        error = default_error_coercer(exception)
+    def custom_error_coercer(exception, error):
         error["message"] = error["message"] + "Custom"
         return error
 


### PR DESCRIPTION
The `error_coercer` signature changed from `Callable[[Exception]] -> dict` to `Callable[[Exception], dict] -> dict`.

The main idea of this change is to avoid calling the coerce_value himself within its own error_coercer implement, as this call must be executed by the engine.

Here are 2 examples of a custom error_coercer, the first one with the old way and the second one with the new way.

*Old way*
```python
from myvender import CustomException
from tartiflette.engine import Engine
from tartiflette.resolver.factory import default_error_coercer

def my_custom_error_coercer(exception):
    error = default_error_coercer(exception)

    if isinstance(exception, CustomException):
        error["customfield"] = "blabla"

    return error

engine = Engine(
    # parameters ...
    error_coercer=my_custom_error_coercer
)
```

**New way**
```python
from myvender import CustomException
from tartiflette.engine import Engine
from tartiflette.resolver.factory import default_error_coercer

def my_custom_error_coercer(exception, error):
    if isinstance(exception, CustomException):
        error["customfield"] = "blabla"

    return error

engine = Engine(
    # parameters ...
    error_coercer=my_custom_error_coercer
)
```
